### PR TITLE
게시글 리스트 보기 및 필터링 기능 및 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ submodules
 ### CustomYml ###
 src/main/resources/application-*.yml
 
+### QClass ###
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ dependencies {
     implementation("it.ozimov:embedded-redis:0.7.2")
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-core:5.0.0'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 }
 
 test {
@@ -119,4 +124,13 @@ jacocoTestCoverageVerification {
             ] + Qdomains
         }
     }
+}
+
+// QueryDSL
+def querydslSrcDir = 'src/main/generated'
+clean {
+    delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/com/flytrap/rssreader/domain/post/Post.java
+++ b/src/main/java/com/flytrap/rssreader/domain/post/Post.java
@@ -1,0 +1,40 @@
+package com.flytrap.rssreader.domain.post;
+
+import com.flytrap.rssreader.global.model.DefaultDomain;
+import com.flytrap.rssreader.global.model.Domain;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Domain(name = "post")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post implements DefaultDomain {
+
+    private Long id;
+    private Long subscribeId;
+    private String guid;
+    private String title;
+    private String description;
+    private Instant pubDate;
+    private String subscribeTitle;
+    private boolean open;
+    private boolean bookmark;
+    // TODO: react
+
+    @Builder
+    protected Post(Long id, Long subscribeId, String guid, String title, String description,
+        Instant pubDate, String subscribeTitle, boolean open, boolean bookmark) {
+        this.id = id;
+        this.subscribeId = subscribeId;
+        this.guid = guid;
+        this.title = title;
+        this.description = description;
+        this.pubDate = pubDate;
+        this.subscribeTitle = subscribeTitle;
+        this.open = open;
+        this.bookmark = bookmark;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/bookmark/BookmarkEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/bookmark/BookmarkEntity.java
@@ -1,0 +1,41 @@
+package com.flytrap.rssreader.infrastructure.entity.bookmark;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "bookmark")
+public class BookmarkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Builder
+    protected BookmarkEntity(Long id, Long memberId, Long postId) {
+        this.id = id;
+        this.memberId = memberId;
+        this.postId = postId;
+    }
+
+    public boolean isSameMember(Long memberId) {
+        return Objects.equals(this.memberId, memberId);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/OpenEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/OpenEntity.java
@@ -1,0 +1,41 @@
+package com.flytrap.rssreader.infrastructure.entity.post;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "open")
+public class OpenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Builder
+    protected OpenEntity(Long id, Long memberId, Long postId) {
+        this.id = id;
+        this.memberId = memberId;
+        this.postId = postId;
+    }
+
+    public boolean isSameMember(Long memberId) {
+        return Objects.equals(this.memberId, memberId);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/PostEntity.java
@@ -1,6 +1,8 @@
 package com.flytrap.rssreader.infrastructure.entity.post;
 
+import com.flytrap.rssreader.domain.post.Post;
 import com.flytrap.rssreader.infrastructure.api.dto.RssItemResource;
+import com.flytrap.rssreader.infrastructure.entity.bookmark.BookmarkEntity;
 import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,10 +12,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,23 +45,34 @@ public class PostEntity {
     @Column(columnDefinition = "LONGTEXT", nullable = false)
     private String description;
 
+    @Temporal(TemporalType.TIMESTAMP)
+    private Instant pubDate;
+
     @ManyToOne
     @JoinColumn(name = "subscribe_id")
     private SubscribeEntity subscribe;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private Instant pubDate;
+    @OneToMany
+    @JoinColumn(name = "post_id")
+    private List<OpenEntity> opens = new ArrayList<OpenEntity>();
 
-    // TODO: Bookmark, Open, React 추가하기
+    @OneToMany
+    @JoinColumn(name = "post_id")
+    private List<BookmarkEntity> bookmarks = new ArrayList<BookmarkEntity>();
+
+    // TODO: React, Thumbnail 추가 하기
 
     @Builder
-    protected PostEntity(Long id, String guid, String title, String description, SubscribeEntity subscribe, Instant pubDate) {
+    protected PostEntity(Long id, String guid, String title, String description, Instant pubDate,
+        SubscribeEntity subscribe, List<OpenEntity> opens, List<BookmarkEntity> bookmarks) {
         this.id = id;
         this.guid = guid;
         this.title = title;
         this.description = description;
-        this.subscribe = subscribe;
         this.pubDate = pubDate;
+        this.subscribe = subscribe;
+        this.opens = opens;
+        this.bookmarks = bookmarks;
     }
 
     public static PostEntity from(RssItemResource rssItemResource, SubscribeEntity subscribe) {
@@ -71,6 +88,38 @@ public class PostEntity {
     public void updateBy(RssItemResource itemResource) {
         this.title = itemResource.title();
         this.description = itemResource.description();
+    }
+
+    public Post toDomain() {
+        return Post.builder()
+            .id(id)
+            .subscribeId(subscribe.getId())
+            .guid(guid)
+            .title(title)
+            .description(description)
+            .pubDate(pubDate)
+            .subscribeTitle(subscribe.getTitle())
+            .build();
+    }
+
+    public boolean isOpen(Long memberId) {
+        for (OpenEntity o : opens) {
+            if (o.isSameMember(memberId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean isBookmark(Long memberId) {
+        for (BookmarkEntity b : bookmarks) {
+            if (b.isSameMember(memberId)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
@@ -30,6 +30,9 @@ public class SubscribeEntity {
     private Long id;
 
     @Column(length = 2500, nullable = false)
+    private String title;
+
+    @Column(length = 2500, nullable = false)
     private String description;
 
     @Column(length = 2500, nullable = false)

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostEntityJpaRepository.java
@@ -5,6 +5,6 @@ import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostEntityJpaRepository extends JpaRepository<PostEntity, Long>  {
+public interface PostEntityJpaRepository extends JpaRepository<PostEntity, Long> {
     List<PostEntity> findAllBySubscribeOrderByPubDateDesc(SubscribeEntity subscribe);
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
@@ -1,0 +1,60 @@
+package com.flytrap.rssreader.infrastructure.repository;
+
+import static com.flytrap.rssreader.infrastructure.entity.post.QOpenEntity.openEntity;
+import static com.flytrap.rssreader.infrastructure.entity.post.QPostEntity.postEntity;
+
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import com.flytrap.rssreader.presentation.dto.PostFilter;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+public class PostListReadDslRepository implements PostListReadRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PostListReadDslRepository(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    public List<PostEntity> findAllBySubscribe(long subscribeId, PostFilter postFilter, Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder
+            .and(postEntity.subscribe.id.eq(subscribeId));
+
+        if (StringUtils.hasText(postFilter.keyword())) {
+            builder
+                .and(postEntity.title.contains(postFilter.keyword()))
+                .and(postEntity.description.contains(postFilter.keyword()));
+        }
+
+        if (postFilter.start() != null && postFilter.end() != null) {
+            builder
+                .and(postEntity.pubDate.between(
+                    Instant.ofEpochMilli(postFilter.start()),
+                    Instant.ofEpochMilli(postFilter.end()))
+                );
+        }
+
+        if (postFilter.read() != null && postFilter.read()) {
+            builder.and(openEntity.isNotNull());
+        } else if (postFilter.read() != null) {
+            builder.and(openEntity.isNull());
+        }
+
+        return queryFactory.selectFrom(postEntity)
+            .leftJoin(openEntity).on(postEntity.id.eq(openEntity.postId))
+            .where(builder)
+            .orderBy(postEntity.pubDate.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
@@ -1,5 +1,6 @@
 package com.flytrap.rssreader.infrastructure.repository;
 
+import static com.flytrap.rssreader.infrastructure.entity.folder.QFolderEntity.folderEntity;
 import static com.flytrap.rssreader.infrastructure.entity.folder.QFolderSubscribeEntity.folderSubscribeEntity;
 import static com.flytrap.rssreader.infrastructure.entity.post.QOpenEntity.openEntity;
 import static com.flytrap.rssreader.infrastructure.entity.post.QPostEntity.postEntity;
@@ -54,6 +55,26 @@ public class PostListReadDslRepository implements PostListReadRepository {
             .leftJoin(openEntity).on(postEntity.id.eq(openEntity.postId))
             .join(subscribeEntity).on(postEntity.subscribe.id.eq(subscribeEntity.id))
             .join(folderSubscribeEntity).on(subscribeEntity.id.eq(folderSubscribeEntity.subscribeId))
+            .where(builder)
+            .orderBy(postEntity.pubDate.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    public List<PostEntity> findAllByMember(long memberId, PostFilter postFilter, Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder
+            .and(folderEntity.memberId.eq(memberId));
+
+        addFilterCondition(builder, postFilter);
+
+        return queryFactory.selectFrom(postEntity)
+            .leftJoin(openEntity).on(postEntity.id.eq(openEntity.postId))
+            .join(subscribeEntity).on(postEntity.subscribe.id.eq(subscribeEntity.id))
+            .join(folderSubscribeEntity).on(subscribeEntity.id.eq(folderSubscribeEntity.subscribeId))
+            .join(folderEntity).on(folderSubscribeEntity.folderId.eq(folderEntity.id))
             .where(builder)
             .orderBy(postEntity.pubDate.desc())
             .offset(pageable.getOffset())

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
@@ -2,7 +2,6 @@ package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
-import com.querydsl.core.BooleanBuilder;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +9,6 @@ public interface PostListReadRepository {
     List<PostEntity> findAllBySubscribe(long subscribeId, PostFilter postFilter, Pageable pageable);
 
     List<PostEntity> findAllByFolder(long folderId, PostFilter postFilter, Pageable pageable);
+
+    List<PostEntity> findAllByMember(long memberId, PostFilter postFilter, Pageable pageable);
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
@@ -2,9 +2,12 @@ package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
+import com.querydsl.core.BooleanBuilder;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface PostListReadRepository {
     List<PostEntity> findAllBySubscribe(long subscribeId, PostFilter postFilter, Pageable pageable);
+
+    List<PostEntity> findAllByFolder(long folderId, PostFilter postFilter, Pageable pageable);
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadRepository.java
@@ -1,0 +1,10 @@
+package com.flytrap.rssreader.infrastructure.repository;
+
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import com.flytrap.rssreader.presentation.dto.PostFilter;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface PostListReadRepository {
+    List<PostEntity> findAllBySubscribe(long subscribeId, PostFilter postFilter, Pageable pageable);
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
@@ -60,4 +60,18 @@ public class PostListReadController {
             new PostListResponse(posts));
     }
 
+    @GetMapping("/posts")
+    public ApplicationResponse<PostListResponse> getPostsByMember(
+        PostFilter postFilter,
+        @PageableDefault(page = 0, size = 15) Pageable pageable,
+        @Login SessionMember member) {
+
+        List<PostResponse> posts = postListReadService.getPostsByMember(member, postFilter, pageable)
+            .stream()
+            .map(PostResponse::from)
+            .toList();
+
+        return new ApplicationResponse<>(
+            new PostListResponse(posts));
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
@@ -1,11 +1,13 @@
 package com.flytrap.rssreader.presentation.controller;
 
+import com.flytrap.rssreader.domain.folder.Folder;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
 import com.flytrap.rssreader.presentation.dto.PostResponse;
 import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.resolver.Login;
+import com.flytrap.rssreader.service.FolderVerifyOwnerService;
 import com.flytrap.rssreader.service.PostListReadService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostListReadController {
 
     private final PostListReadService postListReadService;
+    private final FolderVerifyOwnerService folderVerifyOwnerService;
 
     @GetMapping("/subscribes/{subscribeId}/posts")
     public ApplicationResponse<PostListResponse> getPostsBySubscribe(
@@ -46,7 +49,9 @@ public class PostListReadController {
         @PageableDefault(page = 0, size = 15) Pageable pageable,
         @Login SessionMember member) {
 
-        List<PostResponse> posts = postListReadService.getPostsByFolder(folderId, postFilter, pageable)
+        Folder verifyFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
+
+        List<PostResponse> posts = postListReadService.getPostsByFolder(verifyFolder, postFilter, pageable)
             .stream()
             .map(PostResponse::from)
             .toList();

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
@@ -1,0 +1,39 @@
+package com.flytrap.rssreader.presentation.controller;
+
+import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.presentation.dto.PostFilter;
+import com.flytrap.rssreader.presentation.dto.PostResponse;
+import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
+import com.flytrap.rssreader.service.PostListReadService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/subscribes/{subscribeId}/posts")
+public class PostListReadController {
+
+    private final PostListReadService postListReadService;
+
+    @GetMapping
+    public ApplicationResponse<PostListResponse> getPostsByFolder(
+            @PathVariable Long subscribeId,
+            PostFilter postFilter,
+            @PageableDefault(page = 0, size = 15) Pageable pageable) {
+
+        List<PostResponse> posts = postListReadService.getPosts(subscribeId, postFilter, pageable)
+            .stream()
+            .map(PostResponse::from)
+            .toList();
+
+        return new ApplicationResponse<>(
+            new PostListResponse(posts));
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
@@ -4,6 +4,8 @@ import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
 import com.flytrap.rssreader.presentation.dto.PostResponse;
 import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
+import com.flytrap.rssreader.presentation.dto.SessionMember;
+import com.flytrap.rssreader.presentation.resolver.Login;
 import com.flytrap.rssreader.service.PostListReadService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,18 +18,35 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/subscribes/{subscribeId}/posts")
+@RequestMapping("/api")
 public class PostListReadController {
 
     private final PostListReadService postListReadService;
 
-    @GetMapping
-    public ApplicationResponse<PostListResponse> getPostsByFolder(
+    @GetMapping("/subscribes/{subscribeId}/posts")
+    public ApplicationResponse<PostListResponse> getPostsBySubscribe(
             @PathVariable Long subscribeId,
             PostFilter postFilter,
-            @PageableDefault(page = 0, size = 15) Pageable pageable) {
+            @PageableDefault(page = 0, size = 15) Pageable pageable,
+            @Login SessionMember member) {
 
-        List<PostResponse> posts = postListReadService.getPosts(subscribeId, postFilter, pageable)
+        List<PostResponse> posts = postListReadService.getPostsBySubscribe(subscribeId, postFilter, pageable)
+            .stream()
+            .map(PostResponse::from)
+            .toList();
+
+        return new ApplicationResponse<>(
+            new PostListResponse(posts));
+    }
+
+    @GetMapping("/folders/{folderId}/posts")
+    public ApplicationResponse<PostListResponse> getPostsByFolder(
+        @PathVariable Long folderId,
+        PostFilter postFilter,
+        @PageableDefault(page = 0, size = 15) Pageable pageable,
+        @Login SessionMember member) {
+
+        List<PostResponse> posts = postListReadService.getPostsByFolder(folderId, postFilter, pageable)
             .stream()
             .map(PostResponse::from)
             .toList();

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/PostFilter.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/PostFilter.java
@@ -1,0 +1,9 @@
+package com.flytrap.rssreader.presentation.dto;
+
+public record PostFilter(Boolean read,
+                         Long start,
+                         Long end,
+                         String keyword
+) {
+
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
@@ -1,0 +1,33 @@
+package com.flytrap.rssreader.presentation.dto;
+
+import com.flytrap.rssreader.domain.post.Post;
+import java.time.Instant;
+import java.util.List;
+
+public record PostResponse(
+    String guid,
+    String title,
+    String description,
+    Instant pubDate,
+    String subscribeTitle,
+    boolean open,
+    boolean bookmark
+) {
+
+    public record PostListResponse(
+        List<PostResponse> posts
+        // TODO: react
+    ) { }
+
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+            post.getGuid(),
+            post.getTitle(),
+            post.getDescription(),
+            post.getPubDate(),
+            post.getSubscribeTitle(),
+            post.isOpen(),
+            post.isBookmark()
+        );
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
@@ -15,8 +15,15 @@ public class PostListReadService {
 
     private final PostListReadRepository postListReadRepository;
 
-    public List<Post> getPosts(Long subscribeId, PostFilter postFilter, Pageable pageable) {
+    public List<Post> getPostsBySubscribe(Long subscribeId, PostFilter postFilter, Pageable pageable) {
         return postListReadRepository.findAllBySubscribe(subscribeId, postFilter, pageable)
+            .stream()
+            .map(PostEntity::toDomain)
+            .toList();
+    }
+
+    public List<Post> getPostsByFolder(Long folderId, PostFilter postFilter, Pageable pageable) {
+        return postListReadRepository.findAllByFolder(folderId, postFilter, pageable)
             .stream()
             .map(PostEntity::toDomain)
             .toList();

--- a/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
@@ -5,6 +5,7 @@ import com.flytrap.rssreader.domain.post.Post;
 import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.repository.PostListReadRepository;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
+import com.flytrap.rssreader.presentation.dto.SessionMember;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,13 @@ public class PostListReadService {
 
     public List<Post> getPostsByFolder(Folder folder, PostFilter postFilter, Pageable pageable) {
         return postListReadRepository.findAllByFolder(folder.getId(), postFilter, pageable)
+            .stream()
+            .map(PostEntity::toDomain)
+            .toList();
+    }
+
+    public List<Post> getPostsByMember(SessionMember member, PostFilter postFilter, Pageable pageable) {
+        return postListReadRepository.findAllByMember(1L, postFilter, pageable)
             .stream()
             .map(PostEntity::toDomain)
             .toList();

--- a/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
@@ -1,0 +1,24 @@
+package com.flytrap.rssreader.service;
+
+import com.flytrap.rssreader.domain.post.Post;
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import com.flytrap.rssreader.infrastructure.repository.PostListReadRepository;
+import com.flytrap.rssreader.presentation.dto.PostFilter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class PostListReadService {
+
+    private final PostListReadRepository postListReadRepository;
+
+    public List<Post> getPosts(Long subscribeId, PostFilter postFilter, Pageable pageable) {
+        return postListReadRepository.findAllBySubscribe(subscribeId, postFilter, pageable)
+            .stream()
+            .map(PostEntity::toDomain)
+            .toList();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostListReadService.java
@@ -1,5 +1,6 @@
 package com.flytrap.rssreader.service;
 
+import com.flytrap.rssreader.domain.folder.Folder;
 import com.flytrap.rssreader.domain.post.Post;
 import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.repository.PostListReadRepository;
@@ -22,8 +23,8 @@ public class PostListReadService {
             .toList();
     }
 
-    public List<Post> getPostsByFolder(Long folderId, PostFilter postFilter, Pageable pageable) {
-        return postListReadRepository.findAllByFolder(folderId, postFilter, pageable)
+    public List<Post> getPostsByFolder(Folder folder, PostFilter postFilter, Pageable pageable) {
+        return postListReadRepository.findAllByFolder(folder.getId(), postFilter, pageable)
             .stream()
             .map(PostEntity::toDomain)
             .toList();

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -9,7 +9,11 @@ VALUES ('조금씩, 꾸준히, 자주', '공부는 마라톤이다. 한꺼번에
        ('louie.log', '백엔드 개발자를 준비하고 있는 Louie입니다.', 'https://v2.velog.io/rss/louie', 'VELOG');
 
 INSERT INTO `folder`(name, member_id, is_shared, is_deleted)
-VALUES ('나의 폴더 1', 1, false, false);
+VALUES ('나의 폴더 1', 1, false, false),
+       ('나의 폴더 2', 1, false, false),
+       ('나의 폴더 3', 1, false, false);
 
 INSERT INTO `folder_subscribe`(folder_id, subscribe_id)
-VALUES (1, 1), (1, 2);
+VALUES (1, 1), (1, 2),
+       (2, 1), (2, 3),
+       (3, 4);

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -4,4 +4,12 @@ VALUES ('test', 'test@test.com', 'profile.png', '11111', 'GITHUB', '2023-11-16')
 
 INSERT INTO `rss_subscribe`(title, description, url, platform)
 VALUES ('조금씩, 꾸준히, 자주', '공부는 마라톤이다. 한꺼번에 많은 것을 하다 지치지 말고 조금씩, 꾸준히, 자주하자.', 'https://v2.velog.io/rss/jinny-l', 'VELOG'),
-       ('ape.log', '구명조끼', 'https://v2.velog.io/rss/ape', 'VELOG');
+       ('ape.log', '구명조끼', 'https://v2.velog.io/rss/ape', 'VELOG'),
+       ('janeljs.log', '', 'https://v2.velog.io/rss/janeljs', 'VELOG'),
+       ('louie.log', '백엔드 개발자를 준비하고 있는 Louie입니다.', 'https://v2.velog.io/rss/louie', 'VELOG');
+
+INSERT INTO `folder`(name, member_id, is_shared, is_deleted)
+VALUES ('나의 폴더 1', 1, false, false);
+
+INSERT INTO `folder_subscribe`(folder_id, subscribe_id)
+VALUES (1, 1), (1, 2);

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -2,6 +2,6 @@
 INSERT INTO `member`(name, email, profile, oauth_pk, oauth_server, created_at)
 VALUES ('test', 'test@test.com', 'profile.png', '11111', 'GITHUB', '2023-11-16');
 
-INSERT INTO `rss_subscribe`(description, url, member_id, platform)
-VALUES ('description', 'https://v2.velog.io/rss/jinny-l', '1', 'VELOG'),
-       ('description', 'https://v2.velog.io/rss/ape', '1', 'VELOG');
+INSERT INTO `rss_subscribe`(title, description, url, platform)
+VALUES ('조금씩, 꾸준히, 자주', '공부는 마라톤이다. 한꺼번에 많은 것을 하다 지치지 말고 조금씩, 꾸준히, 자주하자.', 'https://v2.velog.io/rss/jinny-l', 'VELOG'),
+       ('ape.log', '구명조끼', 'https://v2.velog.io/rss/ape', 'VELOG');

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -16,9 +16,9 @@ CREATE TABLE IF NOT EXISTS `member`
 CREATE TABLE IF NOT EXISTS `rss_subscribe`
 (
     `id`          bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `title` varchar(2500) NOT NULL,
     `description` varchar(2500) NOT NULL,
     `url`         varchar(2500) NOT NULL,
-    `member_id`   bigint        NOT NULL,
     `platform`    varchar(25)   NOT NULL
 );
 


### PR DESCRIPTION
## 🔑 Key Changes
- 블로그의 게시글 목록 보기 API 개발
- 폴더의 게시글 목록 보기 API 개발
- 전체 게시글 목록 보기 API 개발

## 👩‍💻 To Reviewers

### API 형식
```json
{
    "data": {
        "posts": [
            {
                "guid": "https://velog.io/@ape/test-l4lqt827",
                "title": "test",
                "description": "<p>test</p>\n",
                "pubDate": "2023-11-08T10:40:18Z",
                "subscribeTitle": "ape.log",
                "open": false,
                "bookmark": false
            },
            {
                "guid": "https://velog.io/@ape/test-9myxk9zq",
                "title": "test",
                "description": "<p>tttt</p>\n",
                "pubDate": "2023-11-08T10:38:36Z",
                "subscribeTitle": "ape.log",
                "open": false,
                "bookmark": false
            },
            {
                "guid": "https://velog.io/@ape/test",
                "title": "test test test test test test test",
                "description": "<p>test</p>\n",
                "pubDate": "2023-11-08T10:36:46Z",
                "subscribeTitle": "ape.log",
                "open": false,
                "bookmark": false
            }
        ]
    }
}
```
### 전달사항
- API 포스트맨에 추가했어요!
- 게시글 목록 읽어오기 객체들은 `PostListRead*`로 분리했습니다.
    - `PostListReadController`에 폴더 게시글 목록 보기 API , 블로그의 게시글 목록 보기 API가 있어요.
    - `TODO`: 북마크 게시글 불러오기는 `BookmarkController`로 따로 빼려고 합니다.

### QueryDSL 추가했어요
- 처음 pull 받으시면 QClass 없어서 에러가 날것으로 예상됩니다.
    - compile 해서 QClass 만들어 주셔야 할것 같습니다.

### subscribe ERD가 변경되어서 같이 맞춰야 할것 같아요
- subscribe에서 description 빠지고 title이 들어 있는데. 다들 반영 된건지?
    - 제 개발 환경에서는 title이 없고 description이 있어서 일단 title 추가하고 description은 그대로 남겨둔 상태입니다.

### `TODO`: 리액션 개발되면 추가해야 합니다.

### `TODO`: 전체 게시글 보기 시 초대 받은 공유 폴더에 있는 게시글은 반환하지 않네요

### 프론트단에 맞춰서 수정해야 될 부분이 생길수도 있습니다.
- 전체 목록에서 폴더 보여주는 부분
- 폴더 페이지에서 폴더 명이랑 멤버들보여주는 부분

## Related to
Closes #64 
