### PR TITLE
리액션 추가, 삭제 API작성

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/reaction/ReactionEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/reaction/ReactionEntity.java
@@ -1,0 +1,55 @@
+package com.flytrap.rssreader.infrastructure.entity.reaction;
+
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "reaction")
+public class ReactionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private PostEntity post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
+    @Column(length = 25)
+    private String emoji;
+
+    @Builder
+    public ReactionEntity(Long id, PostEntity post, MemberEntity member, String emoji) {
+        this.id = id;
+        this.post = post;
+        this.member = member;
+        this.emoji = emoji;
+    }
+
+    public static ReactionEntity create(PostEntity post, MemberEntity member, String emoji) {
+        return ReactionEntity.builder()
+                .post(post)
+                .member(member)
+                .emoji(emoji)
+                .build();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/ReactionEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/ReactionEntityJpaRepository.java
@@ -1,0 +1,8 @@
+package com.flytrap.rssreader.infrastructure.repository;
+
+import com.flytrap.rssreader.infrastructure.entity.reaction.ReactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionEntityJpaRepository extends JpaRepository<ReactionEntity, Long> {
+
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/ReactionEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/ReactionEntityJpaRepository.java
@@ -1,8 +1,12 @@
 package com.flytrap.rssreader.infrastructure.repository;
 
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.entity.reaction.ReactionEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReactionEntityJpaRepository extends JpaRepository<ReactionEntity, Long> {
 
+    Optional<ReactionEntity> findByMemberAndPost(MemberEntity member, PostEntity post);
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostUpdateController.java
@@ -1,0 +1,46 @@
+package com.flytrap.rssreader.presentation.controller;
+
+import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.presentation.dto.ReactionRequest;
+import com.flytrap.rssreader.presentation.dto.SessionMember;
+import com.flytrap.rssreader.presentation.resolver.Login;
+import com.flytrap.rssreader.service.FolderVerifyOwnerService;
+import com.flytrap.rssreader.service.ReactionService;
+import com.flytrap.rssreader.service.SharedFolderReadService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class PostUpdateController {
+
+    private final ReactionService reactionService;
+    private final SharedFolderReadService sharedFolderReadService;
+    private final FolderVerifyOwnerService folderVerifyOwnerService;
+
+    /**
+     * 리액션 반응은 공유된 폴더의 POST만 가능합니다. 공유 된 폴더인지 체크 한 후 POST와 MEMBER사이에 리액션이 일어납니다.
+     *
+     * @param postId
+     * @param member
+     * @return
+     */
+    @PostMapping("/posts/{postId}/reactions")
+    public ApplicationResponse<Long> addReaction(
+            @PathVariable Long postId,
+            @Valid @RequestBody ReactionRequest request,
+            @Login SessionMember member) {
+
+        //TODO: 1.공유된 폴더인가?, 유효한 폴더 인가?
+        // 2.공유폴더에 구독된 POST를 알아야한다
+        Long reaction = reactionService.addReaction(postId, member.id(), request.emoji());
+
+        return new ApplicationResponse<>(reaction);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostUpdateController.java
@@ -9,6 +9,7 @@ import com.flytrap.rssreader.service.ReactionService;
 import com.flytrap.rssreader.service.SharedFolderReadService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,5 +43,17 @@ public class PostUpdateController {
         Long reaction = reactionService.addReaction(postId, member.id(), request.emoji());
 
         return new ApplicationResponse<>(reaction);
+    }
+
+    @DeleteMapping("/posts/{postId}/reactions")
+    public ApplicationResponse<Void> deleteReaction(
+            @PathVariable Long postId,
+            @Login SessionMember member) {
+
+        //TODO: 1.공유된 폴더인가?, 유효한 폴더 인가?
+        // 2.공유폴더에 구독된 POST를 알아야한다
+        reactionService.deleteReaction(postId, member.id());
+
+        return new ApplicationResponse<>(null);
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/ReactionRequest.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/ReactionRequest.java
@@ -1,0 +1,5 @@
+package com.flytrap.rssreader.presentation.dto;
+
+public record ReactionRequest(String emoji) {
+
+}

--- a/src/main/java/com/flytrap/rssreader/service/ReactionService.java
+++ b/src/main/java/com/flytrap/rssreader/service/ReactionService.java
@@ -25,4 +25,13 @@ public class ReactionService {
         MemberEntity member = memberRepository.findById(memberId).orElseThrow();
         return reactionRepository.save(ReactionEntity.create(post, member, emoji)).getId();
     }
+
+    @Transactional
+    public void deleteReaction(Long postId, Long memberId) {
+        PostEntity post = postRepository.findById(postId).orElseThrow();
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow();
+        ReactionEntity reaction = reactionRepository.findByMemberAndPost(member, post)
+                .orElseThrow();
+        reactionRepository.delete(reaction);
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/service/ReactionService.java
+++ b/src/main/java/com/flytrap/rssreader/service/ReactionService.java
@@ -1,0 +1,28 @@
+package com.flytrap.rssreader.service;
+
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import com.flytrap.rssreader.infrastructure.entity.reaction.ReactionEntity;
+import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
+import com.flytrap.rssreader.infrastructure.repository.PostEntityJpaRepository;
+import com.flytrap.rssreader.infrastructure.repository.ReactionEntityJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionService {
+
+    private final PostEntityJpaRepository postRepository;
+    private final MemberEntityJpaRepository memberRepository;
+    private final ReactionEntityJpaRepository reactionRepository;
+
+    @Transactional
+    public Long addReaction(Long postId, Long memberId, String emoji) {
+
+        PostEntity post = postRepository.findById(postId).orElseThrow();
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow();
+        return reactionRepository.save(ReactionEntity.create(post, member, emoji)).getId();
+    }
+}

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -60,3 +60,12 @@ CREATE TABLE `bookmark` (
     `member_id`	bigint	NOT NULL,
     `post_id`	bigint	NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS `post_react` (
+    `id`	    bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `member_id`	bigint	NOT NULL,
+    `post_id`	bigint	NOT NULL,
+    `emoji`     bigint	NOT NULL,
+    FOREIGN KEY (`member_id`) REFERENCES `member`(`id`),
+    FOREIGN KEY (`post_id`) REFERENCES `rss_post`(`id`)
+);

--- a/src/test/java/com/flytrap/rssreader/service/ReactionServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/ReactionServiceTest.java
@@ -1,0 +1,62 @@
+package com.flytrap.rssreader.service;
+
+import static com.flytrap.rssreader.fixture.FixtureFactory.generateMemberEntity;
+import static com.flytrap.rssreader.fixture.FixtureFactory.generatePostEntity;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
+import com.flytrap.rssreader.infrastructure.entity.reaction.ReactionEntity;
+import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
+import com.flytrap.rssreader.infrastructure.repository.PostEntityJpaRepository;
+import com.flytrap.rssreader.infrastructure.repository.ReactionEntityJpaRepository;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("ReactionServic 서비스 로직 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+public class ReactionServiceTest {
+
+    @Mock
+    PostEntityJpaRepository postRepository;
+
+    @Mock
+    MemberEntityJpaRepository memberRepository;
+
+    @Mock
+    ReactionEntityJpaRepository reactionRepository;
+
+    @InjectMocks
+    ReactionService reactionService;
+
+    @Test
+    @DisplayName("POST에 이모지 리액션 달기 성공.")
+    void post_add_reaction_success() {
+
+        // given
+        MemberEntity member = generateMemberEntity();
+        PostEntity post = generatePostEntity(1L);
+
+        // when
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(reactionRepository.save(Mockito.any(ReactionEntity.class)))
+                .thenAnswer(i -> i.getArguments()[0]);
+        reactionService.addReaction(post.getId(), member.getId(), "👍");
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            verify(reactionRepository, times(1)).save(any());
+        });
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 회원이 Post에 리액션을 추가, 삭제 할 수 있도록 리액션 도메인 추가합니다.

## 👩‍💻 To Reviewers
- 추가, 삭제 기능이 있습니다.
- 컨트롤러, 서비스,리포지토리 등 레이어를 만들었습니다.

## Related to
- 
