### PR TITLE
폴더 리스트 반환시 함께 반환하는 부가 정보 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/folder/Folder.java
+++ b/src/main/java/com/flytrap/rssreader/domain/folder/Folder.java
@@ -2,6 +2,9 @@ package com.flytrap.rssreader.domain.folder;
 
 import com.flytrap.rssreader.global.model.DefaultDomain;
 import com.flytrap.rssreader.global.model.Domain;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +20,7 @@ public class Folder implements DefaultDomain {
     private Long memberId;
     private SharedStatus sharedStatus;
     private Boolean isDeleted;
+    private List<FolderSubscribe> subscribes = new ArrayList<>();
 
     @Builder
     protected Folder(Long id, String name, Long memberId, Boolean isShared, Boolean isDeleted) {
@@ -69,5 +73,36 @@ public class Folder implements DefaultDomain {
 
     public boolean isOwner(long id) {
         return this.memberId == id;
+    }
+
+    public void addSubscribe(FolderSubscribe subscribe) {
+        this.subscribes.add(subscribe);
+    }
+
+    public void addAllSubscribes(List<FolderSubscribe> subscribes) {
+        this.subscribes.addAll(subscribes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Folder && ((Folder) obj).getId().equals(this.id);
+    }
+
+    public List<Long> getSubscribeIds() {
+        return subscribes.stream()
+                .map(FolderSubscribe::getId)
+                .toList();
+    }
+
+    public void addUnreadCountsBySubscribes(Map<Long, Integer> countsPost, Map<Long, Integer> countsOpen) {
+        for (FolderSubscribe subscribe : subscribes) {
+            subscribe.addUnreadCount(countsPost.get(subscribe.getId()), countsOpen.get(subscribe.getId()));
+        }
+    }
+
+    public int getUnreadCount() {
+        return subscribes.stream()
+                .mapToInt(FolderSubscribe::getUnreadCount)
+                .sum();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/domain/folder/FolderSubscribe.java
+++ b/src/main/java/com/flytrap/rssreader/domain/folder/FolderSubscribe.java
@@ -1,0 +1,35 @@
+package com.flytrap.rssreader.domain.folder;
+
+import com.flytrap.rssreader.domain.subscribe.Subscribe;
+import com.flytrap.rssreader.global.model.Domain;
+import lombok.Getter;
+
+@Getter
+@Domain(name = "folderSubscribe")
+public class FolderSubscribe {
+
+    private Long id;
+    private String title;
+    private Integer unreadCount;
+    private Integer postCount;
+    private Integer openCount;
+
+    public FolderSubscribe(Long id, String title, Integer unreadCount) {
+        this.id = id;
+        this.title = title;
+        this.unreadCount = unreadCount;
+    }
+
+    public static FolderSubscribe from(Subscribe subscribes) {
+        return new FolderSubscribe(subscribes.getId(), subscribes.getTitle(), 0);
+    }
+
+    public void addUnreadCount(Integer post, Integer open) {
+        int postCount = post == null ? 0 : post;
+        int openCount = open == null ? 0 : open;
+
+        this.postCount = postCount;
+        this.openCount = openCount;
+        this.unreadCount = postCount - openCount;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/domain/shared/SharedFolder.java
+++ b/src/main/java/com/flytrap/rssreader/domain/shared/SharedFolder.java
@@ -9,7 +9,7 @@ public class SharedFolder extends Folder {
 
     private List<Member> invitedMembers = new ArrayList<>();
 
-    public SharedFolder(Long id, String name, Long memberId, Boolean isDeleted, List<Member> invitedMembers) {
+    protected SharedFolder(Long id, String name, Long memberId, Boolean isDeleted, List<Member> invitedMembers) {
         super(id, name, memberId, true, isDeleted);
         this.invitedMembers = invitedMembers;
     }
@@ -20,6 +20,10 @@ public class SharedFolder extends Folder {
 
     public List<Member> getInvitedMembers() {
         return List.of(invitedMembers.toArray(new Member[0]));
+    }
+
+    public static SharedFolder of (Folder folder, List<Member> invitedMembers) {
+        return new SharedFolder(folder.getId(), folder.getName(), folder.getMemberId(), folder.getIsDeleted(), invitedMembers);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
+++ b/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
@@ -13,12 +13,14 @@ import lombok.NoArgsConstructor;
 public class Subscribe implements DefaultDomain {
 
     private Long id;
+    private String title;
     private String url;
     private String description;
 
     @Builder
-    protected Subscribe(Long id, String url, String description) {
+    public Subscribe(Long id, String title, String url, String description) {
         this.id = id;
+        this.title = title;
         this.url = url;
         this.description = description;
     }
@@ -30,17 +32,10 @@ public class Subscribe implements DefaultDomain {
                 .build();
     }
 
-    public static Subscribe of(Long id, String url, String description) {
+    public static Subscribe of(Long id, String title, String url) {
         return Subscribe.builder()
                 .id(id)
-                .url(url)
-                .description(description)
-                .build();
-    }
-
-    public static Subscribe of(Long id, String url) {
-        return Subscribe.builder()
-                .id(id)
+                .title(title)
                 .url(url)
                 .build();
     }

--- a/src/main/java/com/flytrap/rssreader/global/event/PublishEventAspect.java
+++ b/src/main/java/com/flytrap/rssreader/global/event/PublishEventAspect.java
@@ -1,25 +1,16 @@
 package com.flytrap.rssreader.global.event;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-
-import io.micrometer.common.util.StringUtils;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.AfterReturning;
-import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.SpelParseException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -80,7 +71,8 @@ public class PublishEventAspect implements ApplicationEventPublisherAware {
         return evaluationContext;
     }
 
-    private void setVariables(StandardEvaluationContext evaluationContext, JoinPoint joinPoint, String SpEL)
+    private void setVariables(StandardEvaluationContext evaluationContext, JoinPoint joinPoint,
+            String SpEL)
             throws SpelParseException {
         int variableCount = SpEL.length() - SpEL.replace("#", "").length();
         String[] parameterNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
@@ -53,11 +53,11 @@ public class SubscribeEntity {
     }
 
     public Subscribe toDomain(RssFeedData rssFeedData) {
-        return Subscribe.of(this.id, url, rssFeedData.description());
+        return Subscribe.of(this.id, rssFeedData.title(), url);
     }
 
     public Subscribe toDomain() {
-        return Subscribe.of(this.id, this.url);
+        return Subscribe.of(this.id, this.title, this.url);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/FolderSubscribeEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/FolderSubscribeEntityJpaRepository.java
@@ -16,4 +16,6 @@ public interface FolderSubscribeEntityJpaRepository extends
             @Param("folderId") Long folderId);
 
     List<FolderSubscribeEntity> findAllByFolderId(Long folderId);
+
+    List<FolderSubscribeEntity> findAllByFolderIdIn(List<Long> folderIds);
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostEntityJpaRepository.java
@@ -2,9 +2,28 @@ package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostEntityJpaRepository extends JpaRepository<PostEntity, Long> {
     List<PostEntity> findAllBySubscribeOrderByPubDateDesc(SubscribeEntity subscribe);
+    @Query("select p.subscribe.id as subscribeId, count(p) as postCount from PostEntity p where p.subscribe.id in :subscribes group by p.subscribe.id")
+    List<Object[]> findSubscribeCounts(@Param("subscribes") List<Long> subscribes);
+
+    default Map<Long, Integer> countsGroupBySubscribeId(List<Long> subscribes) {
+        List<Object[]> resultList = findSubscribeCounts(subscribes);
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : resultList) {
+            Long subscribeId = (Long) row[0];
+            Integer postCount = ((Number) row[1]).intValue(); // count(p)는 Number 타입이므로 적절한 형변환 필요
+            result.put(subscribeId, postCount);
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
@@ -1,9 +1,33 @@
 package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.post.OpenEntity;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostOpenRepository extends JpaRepository<OpenEntity, Long> {
 
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
+    @Query("select o.postId, count(o.postId) "
+            + "from OpenEntity o "
+            + "where o.memberId = :id and o.postId in :subscribes "
+            + "group by o.postId")
+    List<Object[]> countOpens(@Param("id") long id, @Param("subscribes") List<Long> subscribes);
+
+    default Map<Long, Integer> countsGroupBySubscribeId(long id, List<Long> subscribes) {
+        List<Object[]> resultList = countOpens(id, subscribes);
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : resultList) {
+            Long subscribeId = (Long) row[0];
+            Integer postCount = ((Number) row[1]).intValue(); // count(p)는 Number 타입이므로 적절한 형변환 필요
+            result.put(subscribeId, postCount);
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/SubscribeEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/SubscribeEntityJpaRepository.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
+import java.util.Collection;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,5 @@ public interface SubscribeEntityJpaRepository extends JpaRepository<SubscribeEnt
     boolean existsByUrl(String url);
 
     Optional<SubscribeEntity> findByUrl(String blogUrl);
+
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderReadController.java
@@ -1,21 +1,15 @@
 package com.flytrap.rssreader.presentation.controller;
 
 import com.flytrap.rssreader.domain.folder.Folder;
-import com.flytrap.rssreader.domain.folder.SharedStatus;
-import com.flytrap.rssreader.domain.member.Member;
-import com.flytrap.rssreader.domain.shared.SharedFolder;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
-import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import com.flytrap.rssreader.presentation.dto.Folders;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
+import com.flytrap.rssreader.presentation.facade.InvitedToFolderFacade;
+import com.flytrap.rssreader.presentation.facade.MyFolderFacade;
+import com.flytrap.rssreader.presentation.facade.OpenCheckFacade;
+import com.flytrap.rssreader.presentation.facade.SubscribeInFolderFacade;
 import com.flytrap.rssreader.presentation.resolver.Login;
-import com.flytrap.rssreader.service.FolderReadService;
-import com.flytrap.rssreader.service.MemberService;
-import com.flytrap.rssreader.service.SharedFolderReadService;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,47 +20,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/folders")
 public class FolderReadController {
 
-    private final FolderReadService folderReadService;
-    private final MemberService memberReadService;
-    private final SharedFolderReadService sharedFolderReadService;
+    private final MyFolderFacade myFolderFacade;
+    private final SubscribeInFolderFacade subscribeInFolderFacade;
+    private final OpenCheckFacade openCheckFacade;
+    private final InvitedToFolderFacade invitedToFolderFacade;
 
     @GetMapping
     public ApplicationResponse<Folders> getFolders(@Login SessionMember member) {
 
-        // 내가 생성한 폴더 목록
-        Map<SharedStatus, List<Folder>> folders = folderReadService.findAllByMemberIdGroupByShared(
-                member.id());
-        // 내가 초대받은 폴더 목록
-        List<Long> invitedFolders = sharedFolderReadService.findFoldersInvited(member.id());
-        Map<Long, Folder> foldersGroupById = folderReadService.findAllByIds(invitedFolders)
-                .stream()
-                .collect(Collectors.toMap(Folder::getId, f -> f));
+        // 내가 소속된 폴더 목록 반환
+        List<Folder> folders = myFolderFacade.getMyFoldersMappedBySharedStatus(member.id());
 
-        // TODO: 폴더에 블로그 목록 추가
-        // 감자가 하고있는 거
-        Map<Long, List<SubscribeEntity>> blogMaps = null;
+        // 폴더당 블로그 목록 추가
+        folders = subscribeInFolderFacade.addSubscribesInFolders(folders);
 
-        // 폴더Id마다 초대된 멤버리스트
-        Map<Long, List<Long>> membersInFolders = sharedFolderReadService.findMembersInFolders(
-                invitedFolders);
-        Set<Long> memberIds = membersInFolders.values().stream()
-                .flatMap(List::stream)
-                .collect(Collectors.toSet());
-        Map<Long, Member> membersGroupById = memberReadService.findAllByIds(memberIds)
-                .stream()
-                .collect(Collectors.toMap(Member::getId, m -> m));
+        // 폴더당 초대된 멤버 추가
+        folders = invitedToFolderFacade.getSharedFolders(folders);
 
-        List<SharedFolder> sharedFolders = invitedFolders.stream()
-                .map(e -> {
-                    SharedFolder folder = (SharedFolder) foldersGroupById.get(e);
-                    membersInFolders.get(e).forEach(m -> folder.invite(membersGroupById.get(m)));
-                    return folder;
-                })
-                .toList();
+        // 블로그당 읽지 않은 글 개수 추가
+        folders = openCheckFacade.addUnreadCountInSubscribes(member.id(), folders);
 
-        // TODO 읽지 않은 글 개수, 블로그마다...
-        Map<Long, Long> unreadCountMap = null;
-
-        return new ApplicationResponse(Folders.from(folders, sharedFolders, blogMaps, unreadCountMap));
+        return new ApplicationResponse(Folders.from(folders));
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/FolderListSummary.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/FolderListSummary.java
@@ -2,7 +2,6 @@ package com.flytrap.rssreader.presentation.dto;
 
 import com.flytrap.rssreader.domain.folder.Folder;
 import com.flytrap.rssreader.domain.shared.SharedFolder;
-import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import java.util.List;
 import java.util.Map;
 
@@ -12,22 +11,20 @@ public record FolderListSummary(long id,
                                 List<SubscribeListSummary> blogs,
                                 List<MemberSummary> invitedMembers) {
 
-    public static FolderListSummary from(Folder folder, Map<Long, List<SubscribeEntity>> blogMaps,
-            Map<Long, Long> unreadCountMap) {
-        if (folder instanceof SharedFolder sharedFolder) {
+    public static FolderListSummary from(Folder folder) {
+
+        if (folder instanceof SharedFolder) {
             return new FolderListSummary(folder.getId(),
                     folder.getName(),
-                    unreadCountMap.getOrDefault(folder.getId(), 0L).intValue(),
-                    SubscribeListSummary.from(blogMaps.get(folder.getId()), unreadCountMap),
-                    sharedFolder.getInvitedMembers().stream()
-                            .map(MemberSummary::from)
-                            .toList());
+                    folder.getUnreadCount(),
+                    SubscribeListSummary.from(folder.getSubscribes()),
+                    MemberSummary.from(((SharedFolder) folder).getInvitedMembers()));
         }
 
         return new FolderListSummary(folder.getId(),
                 folder.getName(),
-                unreadCountMap.getOrDefault(folder.getId(), 0L).intValue(),
-                SubscribeListSummary.from(blogMaps.get(folder.getId()), unreadCountMap),
+                folder.getUnreadCount(),
+                SubscribeListSummary.from(folder.getSubscribes()),
                 List.of());
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/Folders.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/Folders.java
@@ -3,33 +3,26 @@ package com.flytrap.rssreader.presentation.dto;
 import com.flytrap.rssreader.domain.folder.Folder;
 import com.flytrap.rssreader.domain.folder.SharedStatus;
 import com.flytrap.rssreader.domain.shared.SharedFolder;
-import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public record Folders(Map<SharedStatus, List<FolderListSummary>> folders) {
 
-    //TODO DTO조립할 것!!!
-    public static Folders from(Map<SharedStatus, List<Folder>> folders,
-            List<SharedFolder> sharedFolders,
-            Map<Long, List<SubscribeEntity>> blogMaps,
-            Map<Long, Long> unreadCountMap) {
+    public static Folders from(List<Folder> unreadCountInSubscribes) {
+        Map<SharedStatus, List<Folder>> collect = unreadCountInSubscribes.stream()
+                .collect(Collectors.groupingBy(Folder::getSharedStatus));
 
-        List<FolderListSummary> sharedFolderSummary = new ArrayList<>();
+        Map<SharedStatus, List<FolderListSummary>> result = Map.of(SharedStatus.SHARED,
+                collect.getOrDefault(SharedStatus.SHARED, new ArrayList<>()).stream()
+                        .map(FolderListSummary::from)
+                        .collect(Collectors.toList()),
+                SharedStatus.PRIVATE,
+                collect.getOrDefault(SharedStatus.PRIVATE, new ArrayList<>()).stream()
+                        .map(FolderListSummary::from)
+                        .collect(Collectors.toList()));
 
-        sharedFolderSummary.addAll(sharedFolders.stream()
-                .map(folder -> FolderListSummary.from(folder, blogMaps, unreadCountMap))
-                .toList());
-
-        sharedFolderSummary.addAll(folders.get(SharedStatus.SHARED).stream()
-                .map(folder -> FolderListSummary.from(folder, blogMaps, unreadCountMap))
-                .toList());
-
-        return new Folders(Map.of(
-                SharedStatus.SHARED, sharedFolderSummary,
-                SharedStatus.PRIVATE, folders.get(SharedStatus.PRIVATE).stream()
-                        .map(folder -> FolderListSummary.from(folder, blogMaps, unreadCountMap))
-                        .toList()));
+        return new Folders(result);
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/MemberSummary.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/MemberSummary.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.presentation.dto;
 
 import com.flytrap.rssreader.domain.member.Member;
+import java.util.List;
 
 public record MemberSummary(Long id,
                             String name,
@@ -14,4 +15,9 @@ public record MemberSummary(Long id,
         );
     }
 
+    public static List<MemberSummary> from(List<Member> invitedMembers) {
+        return invitedMembers.stream()
+                .map(MemberSummary::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/SubscribeListSummary.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/SubscribeListSummary.java
@@ -1,18 +1,20 @@
 package com.flytrap.rssreader.presentation.dto;
 
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
 import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import java.util.List;
 import java.util.Map;
 
 public record SubscribeListSummary(long id,
-                                   //String title,
+                                   String title,
                                    int unreadCount) {
 
-    public static List<SubscribeListSummary> from(List<SubscribeEntity> subscribeEntities, Map<Long, Long> unreadCountMap) {
-        return subscribeEntities.stream()
+    public static List<SubscribeListSummary> from(List<FolderSubscribe> subscribes)
+    {
+        return subscribes.stream()
                 .map(e -> new SubscribeListSummary(e.getId(),
-                        //e.getTitle(),
-                        unreadCountMap.getOrDefault(e.getId(), 0L).intValue()))
+                        e.getTitle(),
+                        e.getUnreadCount()))
                 .toList();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/facade/InvitedToFolderFacade.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/facade/InvitedToFolderFacade.java
@@ -1,0 +1,56 @@
+package com.flytrap.rssreader.presentation.facade;
+
+import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.domain.folder.SharedStatus;
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.domain.shared.SharedFolder;
+import com.flytrap.rssreader.service.MemberService;
+import com.flytrap.rssreader.service.SharedFolderReadService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InvitedToFolderFacade {
+
+    private final SharedFolderReadService sharedFolderReadService;
+    private final MemberService memberService;
+
+    public List<Folder> getSharedFolders(List<Folder> folders) {
+        List<Long> folderIds = folders.stream().map(Folder::getId).toList();
+        Map<Long, List<Long>> membersInFolders =    // 폴더마다 초대된 멤버 목록
+                sharedFolderReadService.findMembersInFolders(folderIds);
+
+        Map<Long, Member> memberInfo = getMemberInfomations(membersInFolders);
+
+        return folders.stream()
+                .map(folder -> injectMemberInfo(membersInFolders, memberInfo, folder))
+                .toList();
+    }
+
+    private Folder injectMemberInfo(Map<Long, List<Long>> membersInFolders,
+            Map<Long, Member> memberInfo,
+            Folder folder) {
+        if (folder.getSharedStatus() == SharedStatus.PRIVATE) {
+            return folder;
+        }
+        List<Member> members = membersInFolders.get(folder.getId()).stream()
+                .map(memberInfo::get)
+                .toList();
+        return SharedFolder.of(folder, members);
+    }
+
+    private Map<Long, Member> getMemberInfomations(Map<Long, List<Long>> membersInFolders) {
+        Set<Long> memberSet = membersInFolders.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+
+        return memberService.findAllByIds(memberSet).stream()
+                .collect(Collectors.toMap(Member::getId, member -> member));
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/facade/MyFolderFacade.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/facade/MyFolderFacade.java
@@ -1,0 +1,28 @@
+package com.flytrap.rssreader.presentation.facade;
+
+import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.service.FolderReadService;
+import com.flytrap.rssreader.service.SharedFolderReadService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MyFolderFacade {
+
+    private final FolderReadService folderReadService;
+    private final SharedFolderReadService sharedFolderReadService;
+
+    public List<Folder> getMyFoldersMappedBySharedStatus(long id) {
+        List<Folder> myFolders = folderReadService.findAllByMemberId(id);
+
+        // 내가 초대받은 폴더 목록
+        List<Long> invitedFolderIds = sharedFolderReadService.findFoldersInvited(id);
+        List<Folder> invitedFolders = folderReadService.findAllByIds(invitedFolderIds);
+
+        myFolders.addAll(invitedFolders);
+
+        return myFolders;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/facade/OpenCheckFacade.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/facade/OpenCheckFacade.java
@@ -1,0 +1,32 @@
+package com.flytrap.rssreader.presentation.facade;
+
+import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.service.PostOpenService;
+import com.flytrap.rssreader.service.PostReadService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OpenCheckFacade {
+
+    private final PostReadService postReadService;
+    private final PostOpenService postOpenService;
+
+
+    public List<Folder> addUnreadCountInSubscribes(long id, List<Folder> foldersWithSubscribe) {
+        List<Long> subscribes = foldersWithSubscribe.stream().map(Folder::getSubscribeIds)
+                .flatMap(List::stream).toList();
+
+        Map<Long, Integer> countsPost = postReadService.countPosts(subscribes);
+        Map<Long, Integer> countsOpen = postOpenService.countOpens(id, subscribes);
+
+        for (Folder folder : foldersWithSubscribe) {
+            folder.addUnreadCountsBySubscribes(countsPost, countsOpen);
+        }
+
+        return foldersWithSubscribe;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/facade/SubscribeInFolderFacade.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/facade/SubscribeInFolderFacade.java
@@ -1,0 +1,40 @@
+package com.flytrap.rssreader.presentation.facade;
+
+import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
+import com.flytrap.rssreader.domain.subscribe.Subscribe;
+import com.flytrap.rssreader.service.FolderSubscribeService;
+import com.flytrap.rssreader.service.SubscribeService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscribeInFolderFacade {
+
+    private final SubscribeService subscribeService;
+    private final FolderSubscribeService folderSubscribeService;
+
+    public List<Folder> addSubscribesInFolders(List<Folder> folders) {
+        Map<Folder, List<Long>> folderSubscribeIds =
+                folderSubscribeService.getFolderSubscribeIds(folders);
+
+        Set<Long> subscribeIds = folderSubscribeIds.values().stream()
+                .flatMap(List::stream).collect(Collectors.toSet());
+
+        Map<Long, Subscribe> subscribes = subscribeService.read(subscribeIds).stream()
+                .collect(Collectors.toMap(Subscribe::getId, subscribe -> subscribe));
+
+        folders.forEach(folder -> {
+            List<Long> subscribeIdsInFolder = folderSubscribeIds.get(folder);
+            subscribeIdsInFolder.stream()
+                    .map(subscribes::get)
+                    .forEach(e -> folder.addSubscribe(FolderSubscribe.from(e)));
+        });
+        return folders;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/service/FolderReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/FolderReadService.java
@@ -24,10 +24,10 @@ public class FolderReadService {
     }
 
     @Transactional(readOnly = true)
-    public Map<SharedStatus, List<Folder>> findAllByMemberIdGroupByShared(long memberId) {
+    public List<Folder> findAllByMemberId(long memberId) {
         return repository.findAllByMemberIdAndIsDeletedFalse(memberId).stream()
                 .map(FolderEntity::toDomain)
-                .collect(Collectors.groupingBy(Folder::getSharedStatus));
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/flytrap/rssreader/service/PostOpenService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostOpenService.java
@@ -1,8 +1,9 @@
 package com.flytrap.rssreader.service;
 
-import com.flytrap.rssreader.infrastructure.entity.post.OpenEntity;
 import com.flytrap.rssreader.infrastructure.repository.PostOpenRepository;
 import com.flytrap.rssreader.service.dto.PostOpenParam;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,5 +22,10 @@ public class PostOpenService {
         }
 
         postOpenRepository.save(value.toEntity());
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Integer> countOpens(long id, List<Long> subscribes) {
+        return postOpenRepository.countsGroupBySubscribeId(id, subscribes);
     }
 }

--- a/src/main/java/com/flytrap/rssreader/service/PostReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostReadService.java
@@ -8,6 +8,8 @@ import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.repository.PostEntityJpaRepository;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.service.dto.PostOpenParam;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,5 +31,8 @@ public class PostReadService {
         return post.toDomain(sessionMember.id());
     }
 
-
+    @Transactional(readOnly = true)
+    public Map<Long, Integer> countPosts(List<Long> subscribes) {
+        return postEntityJpaRepository.countsGroupBySubscribeId(subscribes);
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/service/SharedFolderReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/SharedFolderReadService.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SharedFolderReadService {
 
-    private SharedFolderJpaRepository sharedFolderJpaRepository;
+    private final SharedFolderJpaRepository sharedFolderJpaRepository;
 
     /**
      * 멤버Id로 초대된 폴더Id 목록을 반환합니다.

--- a/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
+++ b/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
@@ -6,7 +6,9 @@ import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import com.flytrap.rssreader.infrastructure.repository.SubscribeEntityJpaRepository;
 import com.flytrap.rssreader.presentation.dto.RssFeedData;
 import com.flytrap.rssreader.presentation.dto.SubscribeRequest.CreateRequest;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +53,7 @@ public class SubscribeService {
         return subscribeRepository.findById(subscribedId).orElseThrow();
     }
 
-    public List<Subscribe> read(List<Long> subscribeIds) {
+    public List<Subscribe> read(Collection<Long> subscribeIds) {
         return subscribeIds.stream()
                 .map(subscribeRepository::findById)
                 .filter(Optional::isPresent)


### PR DESCRIPTION
## 🔑 Key Changes
- 각 테이블의 데이터를 취합하여 폴더 리스트를 반환하는 기능을 구현하였습니다.

## 👩‍💻 To Reviewers
- 쿼리가 총 8번 실행됩니다.
```sql
-- 1. 특정 회원이 소유하고 삭제되지 않은(Folder.is_deleted가 false) 폴더 목록을 가져오는 쿼리
select
    f1_0.id, f1_0.is_deleted, f1_0.is_shared, f1_0.member_id, f1_0.name 
from
    folder f1_0 
where
    f1_0.member_id=? and not(f1_0.is_deleted);

-- 2. 특정 회원이 속한 폴더의 멤버 목록을 가져오는 쿼리
select
    s1_0.id, s1_0.folder_id, s1_0.member_id 
from
    folder_member s1_0 
where
    s1_0.member_id=?;

-- 3. 특정 폴더들에 대한 구독 목록을 가져오는 쿼리
select
    f1_0.id, f1_0.description, f1_0.folder_id, f1_0.subscribe_id 
from
    folder_subscribe f1_0 
where
    f1_0.folder_id in (?,?,?);

-- 4. 특정 구독 ID들에 해당하는 RSS 구독 정보를 가져오는 쿼리
select
    s1_0.id, s1_0.platform, s1_0.title, s1_0.url 
from
    rss_subscribe s1_0 
where
    s1_0.id in (?,?,?,?);

-- 5. 특정 폴더들에 대한 멤버 목록을 가져오는 쿼리
select
    s1_0.id, s1_0.folder_id, s1_0.member_id 
from
    folder_member s1_0 
where
    s1_0.folder_id in (?,?,?);

-- 6. 특정 회원 ID들에 해당하는 회원 정보를 가져오는 쿼리
select
    m1_0.id, m1_0.created_at, m1_0.email, m1_0.name, m1_0.oauth_pk, m1_0.oauth_server, m1_0.profile 
from
    member m1_0 
where
    m1_0.id in (?);

-- 7. 특정 구독 ID들에 해당하는 RSS 포스트 개수를 가져오는 쿼리
select
    p1_0.subscribe_id, count(p1_0.id) 
from
    rss_post p1_0 
where
    p1_0.subscribe_id in (?,?,?) 
group by
    p1_0.subscribe_id;

-- 8. 특정 회원이 읽은 RSS 포스트 개수를 가져오는 쿼리
select
    o1_0.post_id, count(o1_0.post_id) 
from
    open o1_0 
where
    o1_0.member_id=? and o1_0.post_id in (?,?,?) 
group by
    o1_0.post_id;

```

## Related to
- closed #66 
