### PR TITLE
게시글 수집 시 블로그 플랫폼 마다 상이한 pubDate 공통 처리

### DIFF
--- a/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
+++ b/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
@@ -1,0 +1,49 @@
+package com.flytrap.rssreader.global.utill;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class DateConvertor {
+
+    private static final String DATE_FORMAT_ABBREVIATION = "EEE, dd MMM yyyy HH:mm:ss z";
+    private static final String DATE_FORMAT_NUMERICAL = "EEE, dd MMM yyyy HH:mm:ss Z";
+    private static final String OFFSET_GMT = "GMT";
+    private static final String OFFSET_0000 = "+0000";
+    private static final String OFFSET_0900 = "+0900";
+    private static final String REGEX_SPACE = "\\s+";
+
+    /**
+     * "Wed, 29 Nov 2023 13:49:14 +0900" 및 "Tue, 07 Nov 2023 14:12:30 GMT"
+     * 형식의 문자열을 Instant 객체로 변환하는 메서드
+     *
+     * @param parsingDate Instant 객체로 변경할 날짜 문자열
+     * @return Instant 객체
+     */
+    public static Instant convertToInstant(String parsingDate) {
+        String[] dateParts = parsingDate.split(REGEX_SPACE);
+        String offsetZ = dateParts[dateParts.length - 1];
+
+        DateTimeFormatter formatter = switch (offsetZ) {
+            case OFFSET_GMT -> DateTimeFormatter.ofPattern(DATE_FORMAT_ABBREVIATION)
+                .withLocale(Locale.ENGLISH);
+            case OFFSET_0000, OFFSET_0900 -> DateTimeFormatter.ofPattern(DATE_FORMAT_NUMERICAL)
+                .withLocale(Locale.ENGLISH);
+            default -> throw new IllegalStateException("Unexpected value: " + parsingDate);
+        };
+
+        return Instant.from(formatter.parse(parsingDate));
+    }
+
+    /**
+     * 블로그마다 pubDate 형태가 다 달라서 새로운 블로그 구독할때마다 테스트 해야 할듯합니다.
+     * 테스트하기 쉽게 하기 위해 main메서드를 만들었습니다.
+     * @param args
+     */
+    public static void main(String[] args) {
+        String date = "Tue, 21 Nov 2023 07:30:08 +0000";
+        Instant instant = convertToInstant(date);
+
+        System.out.println(instant);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/RssPostParser.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/RssPostParser.java
@@ -1,16 +1,13 @@
 package com.flytrap.rssreader.infrastructure.api;
 
-import com.flytrap.rssreader.global.exception.NoSuchDomainException;
+import com.flytrap.rssreader.global.utill.DateConvertor;
 import com.flytrap.rssreader.infrastructure.api.dto.RssItemTagName;
 import com.flytrap.rssreader.infrastructure.api.dto.RssSubscribeResource;
 import com.flytrap.rssreader.infrastructure.api.dto.RssSubscribeResource.RssItemResource;
 import com.flytrap.rssreader.infrastructure.api.dto.RssSubscribeTagName;
 import java.io.IOException;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -70,7 +67,7 @@ public class RssPostParser {
                     getTagValue(node, RssItemTagName.GUID),
                     getTagValue(node, RssItemTagName.TITLE),
                     getTagValue(node, RssItemTagName.DESCRIPTION),
-                    convertToInstant(getTagValue(node, RssItemTagName.PUB_DATE))
+                    DateConvertor.convertToInstant(getTagValue(node, RssItemTagName.PUB_DATE))
                 )
             );
         }
@@ -78,18 +75,10 @@ public class RssPostParser {
         return itemResources;
     }
 
-
     private String getTagValue(Node parentNode, RssItemTagName tagName) {
         Element element = (Element) parentNode;
 
         return element.getElementsByTagName(tagName.getTagName()).item(0).getTextContent();
-    }
-
-    private Instant convertToInstant(String parsingDate) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z",
-            Locale.ENGLISH);
-
-        return Instant.from(formatter.parse(parsingDate));
     }
 
 }

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -17,7 +17,8 @@ INSERT INTO `rss_subscribe`(title, url, platform)
 VALUES ('조금씩, 꾸준히, 자주', 'https://v2.velog.io/rss/jinny-l', 'VELOG'),
        ('ape.log', 'https://v2.velog.io/rss/ape', 'VELOG'),
        ('janeljs.log', 'https://v2.velog.io/rss/janeljs', 'VELOG'),
-       ('louie.log', 'https://v2.velog.io/rss/louie', 'VELOG');
+       ('louie.log', 'https://v2.velog.io/rss/louie', 'VELOG'),
+       ('✨ iirin''s space', 'https://new-pow.tistory.com/rss', 'TISTORY');
 
 INSERT INTO `rss_post`(guid, subscribe_id, title, description, pub_date)
 VALUES ('https://velog.io/@ape/test-l4lqt827', 2, 'test', '<p>test</p>\n', '2023-11-08 10:40:18.000000'),

--- a/src/test/java/com/flytrap/rssreader/global/utill/DateConvertorTest.java
+++ b/src/test/java/com/flytrap/rssreader/global/utill/DateConvertorTest.java
@@ -1,0 +1,27 @@
+package com.flytrap.rssreader.global.utill;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DateConvertorTest {
+
+    @Test
+    @DisplayName("다양한 offset을 가진 pubDate를 Instant로 변환할 수 있다.")
+    void convertToInstant() {
+        String[] pubDates = {
+            "Wed, 29 Nov 2023 13:49:14 +0900",
+            "Tue, 07 Nov 2023 14:12:30 GMT",
+            "Tue, 21 Nov 2023 07:30:08 +0000",
+        };
+
+        // 에러가 나지 않으면 Instant로 변환에 성공한 것
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThatCode(() -> {
+            for (String pubDate : pubDates) {
+                DateConvertor.convertToInstant(pubDate);
+            }
+        }).doesNotThrowAnyException();
+        softAssertions.assertAll();
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 게시글 수집 시 블로그 플랫폼 마다 상이한 pubDate 공통 처리
    - rss문서에서 추출한 pubDate를 Instant로 변환해주는 DateConvertor 객체 추가
    - RssPostParser에서 DateConvertor를 사용해서 블로그 플랫폼 마다 상이한 pubDate 공통 처리하도록 변경

## 👩‍💻 To Reviewers
- 이번 PR의 핵심 로직은 DateConvertor에 있어요
- 블로그 마다 pubDate가 다 달라서 새로운 플랫폼 추가할 때마다 pubDate가 잘 변환되는지 테스트해봐야 할 것 같아요

## Related to
- Closes #81 
