### PR TITLE
게시글 수집 시 썸네일 이미지도 수집하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
     // AOP
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    // jsoup HTML parser library @ https://jsoup.org/
+    implementation 'org.jsoup:jsoup:1.17.1'
 }
 
 test {

--- a/src/main/java/com/flytrap/rssreader/domain/post/Post.java
+++ b/src/main/java/com/flytrap/rssreader/domain/post/Post.java
@@ -17,6 +17,7 @@ public class Post implements DefaultDomain {
     private Long subscribeId;
     private String guid;
     private String title;
+    private String thumbnailUrl;
     private String description;
     private Instant pubDate;
     private String subscribeTitle;
@@ -25,12 +26,14 @@ public class Post implements DefaultDomain {
     // TODO: react
 
     @Builder
-    protected Post(Long id, Long subscribeId, String guid, String title, String description,
-        Instant pubDate, String subscribeTitle, boolean open, boolean bookmark) {
+    protected Post(Long id, Long subscribeId, String guid, String title, String thumbnailUrl,
+        String description, Instant pubDate, String subscribeTitle, boolean open,
+        boolean bookmark) {
         this.id = id;
         this.subscribeId = subscribeId;
         this.guid = guid;
         this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
         this.description = description;
         this.pubDate = pubDate;
         this.subscribeTitle = subscribeTitle;

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/HTMLImageParser.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/HTMLImageParser.java
@@ -1,0 +1,24 @@
+package com.flytrap.rssreader.infrastructure.api;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HTMLImageParser {
+
+    private static final String IMG_TAG_NAME = "img";
+    private static final String SRC_ATTRIBUTE_NAME = "src";
+
+    public String extractImageUrl(String html) {
+        Document doc = Jsoup.parse(html);
+        Element imgElement = doc.select(IMG_TAG_NAME).first();
+
+        if (imgElement != null) {
+            return imgElement.attr(SRC_ATTRIBUTE_NAME);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/RssPostParser.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/RssPostParser.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
@@ -24,11 +24,13 @@ import org.xml.sax.SAXException;
  * 구독한 블로그의 RSS 문서에서 게시글을 파싱해 그 결과를 반환하는 RSS 게시글 파서
  */
 @Slf4j
-@NoArgsConstructor
+@AllArgsConstructor
 @Component
 public class RssPostParser {
 
     private static final String RSS_PARSING_ERROR_MESSAGE = "RSS문서를 파싱할 수 없습니다.";
+
+    private final HTMLImageParser htmlImageParser;
 
     public Optional<RssSubscribeResource> parseRssDocuments(String url) {
 
@@ -61,13 +63,15 @@ public class RssPostParser {
 
         for (int i = 0; i < itemList.getLength(); i++) {
             Node node = itemList.item(i);
+            String description = getTagValue(node, RssItemTagName.DESCRIPTION);
 
             itemResources.add(
                 new RssItemResource(
                     getTagValue(node, RssItemTagName.GUID),
                     getTagValue(node, RssItemTagName.TITLE),
-                    getTagValue(node, RssItemTagName.DESCRIPTION),
-                    DateConvertor.convertToInstant(getTagValue(node, RssItemTagName.PUB_DATE))
+                    description,
+                    DateConvertor.convertToInstant(getTagValue(node, RssItemTagName.PUB_DATE)),
+                    htmlImageParser.extractImageUrl(description)
                 )
             );
         }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/RssSubscribeResource.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/RssSubscribeResource.java
@@ -12,7 +12,8 @@ public record RssSubscribeResource(
         String guid,
         String title,
         String description,
-        Instant pubDate
+        Instant pubDate,
+        String thumbnailUrl
     ) {
 
     }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/PostEntity.java
@@ -40,6 +40,9 @@ public class PostEntity {
     @Column(length = 2500, nullable = false)
     private String title;
 
+    @Column(length = 2500, nullable = true)
+    private String thumbnailUrl;
+
     @Lob
     @Column(columnDefinition = "LONGTEXT", nullable = false)
     private String description;
@@ -62,11 +65,12 @@ public class PostEntity {
     // TODO: React, Thumbnail 추가 하기
 
     @Builder
-    protected PostEntity(Long id, String guid, String title, String description, Instant pubDate,
+    protected PostEntity(Long id, String guid, String title, String thumbnailUrl, String description, Instant pubDate,
         SubscribeEntity subscribe, List<OpenEntity> opens, List<BookmarkEntity> bookmarks) {
         this.id = id;
         this.guid = guid;
         this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
         this.description = description;
         this.pubDate = pubDate;
         this.subscribe = subscribe;
@@ -78,6 +82,7 @@ public class PostEntity {
         return PostEntity.builder()
             .guid(rssItemResource.guid())
             .title(rssItemResource.title())
+            .thumbnailUrl(rssItemResource.thumbnailUrl())
             .description(rssItemResource.description())
             .pubDate(rssItemResource.pubDate())
             .subscribe(subscribe)
@@ -86,6 +91,7 @@ public class PostEntity {
 
     public void updateBy(RssItemResource itemResource) {
         this.title = itemResource.title();
+        this.thumbnailUrl = itemResource.thumbnailUrl();
         this.description = itemResource.description();
     }
 
@@ -95,6 +101,7 @@ public class PostEntity {
             .subscribeId(subscribe.getId())
             .guid(guid)
             .title(title)
+            .thumbnailUrl(thumbnailUrl)
             .description(description)
             .pubDate(pubDate)
             .build();
@@ -106,6 +113,7 @@ public class PostEntity {
             .subscribeId(subscribe.getId())
             .guid(guid)
             .title(title)
+            .thumbnailUrl(thumbnailUrl)
             .description(description)
             .pubDate(pubDate)
             .subscribeTitle(subscribe.getTitle())

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record PostResponse(
     String guid,
     String title,
+    String thumbnailUrl,
     String description,
     Instant pubDate,
     String subscribeTitle,
@@ -23,6 +24,7 @@ public record PostResponse(
         return new PostResponse(
             post.getGuid(),
             post.getTitle(),
+            post.getThumbnailUrl(),
             post.getDescription(),
             post.getPubDate(),
             post.getSubscribeTitle(),

--- a/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
@@ -75,6 +75,7 @@ public class PostCollectService {
             postEntityJpaRepository.save(post);
         }
     }
+
     private static Map<String, PostEntity> convertListToHashSet(List<PostEntity> postEntities) {
         Map<String, PostEntity> map = new HashMap<>();
 

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -23,12 +23,13 @@ CREATE TABLE IF NOT EXISTS `rss_subscribe`
 
 CREATE TABLE IF NOT EXISTS `rss_post`
 (
-    `id`           bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `guid`         varchar(2500) NOT NULL,
-    `subscribe_id` bigint        NOT NULL,
-    `title`        varchar(2500) NOT NULL,
-    `description`  longtext      NOT NULL,
-    `pub_date`     timestamp     NOT NULL
+    `id`            bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `guid`          varchar(2500) NOT NULL,
+    `subscribe_id`  bigint        NOT NULL,
+    `title`         varchar(2500) NOT NULL,
+    `thumbnail_url` varchar(2500),
+    `description`   longtext      NOT NULL,
+    `pub_date`      timestamp     NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS `open`


### PR DESCRIPTION
## 🔑 Key Changes
- 게시글 수집 시 썸네일 이미지도 수집하도록 변경

## 👩‍💻 To Reviewers

- 기존에 사용하던  `javax.xml.parsers.DocumentBuilderFactory`은 xml 문서만 파싱이 가능해 Jsoup html 파싱 라이브러리를 추가했습니다. [[jsoup.org]](https://jsoup.org/news/release-1.17.1)
    - `DocumentBuilderFactory`는 xml만 지원해서 html의 self-closing tag가 적용되지 않아서 새로운 라이브러리를 찾게 되었습니다.
    - Jsoup이 최근까지도 업데이트 되고 있고, `DocumentBuilderFactory`보다 더 사용하기 쉬우며, xml, html 문서 모두 파싱 가능합니다
- ‼️ 머지할 때 base를 sprint로 변경해야 합니다.

## Related to
- Close #87  
