### PR TITLE
전체 게시글 리스트 반환 시 공유폴더의 게시글도 반환하도록 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
@@ -6,6 +6,7 @@ import static com.flytrap.rssreader.infrastructure.entity.folder.QFolderEntity.f
 import static com.flytrap.rssreader.infrastructure.entity.folder.QFolderSubscribeEntity.folderSubscribeEntity;
 import static com.flytrap.rssreader.infrastructure.entity.post.QOpenEntity.openEntity;
 import static com.flytrap.rssreader.infrastructure.entity.post.QPostEntity.postEntity;
+import static com.flytrap.rssreader.infrastructure.entity.shared.QSharedFolderEntity.sharedFolderEntity;
 import static com.flytrap.rssreader.infrastructure.entity.subscribe.QSubscribeEntity.subscribeEntity;
 
 import com.flytrap.rssreader.infrastructure.repository.output.PostOutput;
@@ -80,7 +81,8 @@ public class PostListReadDslRepository implements PostListReadRepository {
 
         BooleanBuilder builder = new BooleanBuilder();
         builder
-            .and(folderEntity.memberId.eq(memberId));
+            .and(folderEntity.memberId.eq(memberId))
+            .or(sharedFolderEntity.memberId.eq(memberId));
 
         addFilterCondition(builder, postFilter, memberId);
 
@@ -88,6 +90,7 @@ public class PostListReadDslRepository implements PostListReadRepository {
             .join(subscribeEntity).on(postEntity.subscribe.id.eq(subscribeEntity.id))
             .join(folderSubscribeEntity).on(subscribeEntity.id.eq(folderSubscribeEntity.subscribeId))
             .join(folderEntity).on(folderSubscribeEntity.folderId.eq(folderEntity.id))
+            .leftJoin(sharedFolderEntity).on(folderEntity.id.eq(sharedFolderEntity.folderId))
             .where(builder)
             .orderBy(postEntity.pubDate.desc())
             .offset(pageable.getOffset())

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/PostResponse.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.List;
 
 public record PostResponse(
+    long id,
     String guid,
     String title,
     String thumbnailUrl,
@@ -22,6 +23,7 @@ public record PostResponse(
 
     public static PostResponse from(Post post) {
         return new PostResponse(
+            post.getId(),
             post.getGuid(),
             post.getTitle(),
             post.getThumbnailUrl(),

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -6,19 +6,25 @@ VALUES ('admin', 'admin@gmail.com', 'https://avatars.githubusercontent.com/u/863
 INSERT INTO `folder`(name, member_id, is_shared, is_deleted)
 VALUES ('나의 폴더 1', 1, false, false),
        ('나의 폴더 2', 1, false, false),
-       ('나의 폴더 3', 1, false, false);
+       ('나의 폴더 3', 1, false, false),
+       ('공유 폴더 1', 2, true,  false);
+
+INSERT INTO `folder_member`(member_id, folder_id)
+VALUES (1, 4);
 
 INSERT INTO `folder_subscribe`(folder_id, subscribe_id, description)
 VALUES (1, 1, ''), (1, 2, ''),
        (2, 1, ''), (2, 3, ''),
-       (3, 4, '');
+       (3, 4, ''), (4, 2, ''),
+       (4, 5, ''), (4, 6, '');
 
 INSERT INTO `rss_subscribe`(title, url, platform)
 VALUES ('조금씩, 꾸준히, 자주', 'https://v2.velog.io/rss/jinny-l', 'VELOG'),
        ('ape.log', 'https://v2.velog.io/rss/ape', 'VELOG'),
        ('janeljs.log', 'https://v2.velog.io/rss/janeljs', 'VELOG'),
        ('louie.log', 'https://v2.velog.io/rss/louie', 'VELOG'),
-       ('✨ iirin''s space', 'https://new-pow.tistory.com/rss', 'TISTORY');
+       ('✨ iirin''s space', 'https://new-pow.tistory.com/rss', 'TISTORY'),
+       ('gamja.log', 'https://v2.velog.io/rss/leekhy02', 'VELOG');
 
 INSERT INTO `rss_post`(guid, subscribe_id, title, description, pub_date)
 VALUES ('https://velog.io/@ape/test-l4lqt827', 2, 'test', '<p>test</p>\n', '2023-11-08 10:40:18.000000'),


### PR DESCRIPTION
## 🔑 Key Changes
- 전체 게시글 리스트 반환 시 공유폴더의 게시글도 반환하도록 변경

## 👩‍💻 To Reviewers
- QueryDSL SQL 부분에 약간의 수정만 있습니다.
- 게시글 반환시 id도 반환하도록 했습니다. 프론트에서 게시글을 읽거나 북마크 할때 활용하기 위함입니다.
- ‼️ 머지할 때 base를 sprint로 변경해야 합니다.

## Related to
- Closes #83 
