### PR TITLE
#96 리뷰 반영: pubDate 포맷 변환 로직 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
+++ b/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
@@ -2,16 +2,17 @@ package com.flytrap.rssreader.global.utill;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 public class DateConvertor {
 
     private static final String DATE_FORMAT_ABBREVIATION = "EEE, dd MMM yyyy HH:mm:ss z";
     private static final String DATE_FORMAT_NUMERICAL = "EEE, dd MMM yyyy HH:mm:ss Z";
-    private static final String OFFSET_GMT = "GMT";
-    private static final String OFFSET_0000 = "+0000";
-    private static final String OFFSET_0900 = "+0900";
-    private static final String REGEX_SPACE = "\\s+";
+    private static final DateTimeFormatter[] FORMATTERS = {
+        DateTimeFormatter.ofPattern(DATE_FORMAT_ABBREVIATION).withLocale(Locale.ENGLISH),
+        DateTimeFormatter.ofPattern(DATE_FORMAT_NUMERICAL).withLocale(Locale.ENGLISH),
+    };
 
     /**
      * "Wed, 29 Nov 2023 13:49:14 +0900" 및 "Tue, 07 Nov 2023 14:12:30 GMT"
@@ -21,18 +22,15 @@ public class DateConvertor {
      * @return Instant 객체
      */
     public static Instant convertToInstant(String parsingDate) {
-        String[] dateParts = parsingDate.split(REGEX_SPACE);
-        String offsetZ = dateParts[dateParts.length - 1];
 
-        DateTimeFormatter formatter = switch (offsetZ) {
-            case OFFSET_GMT -> DateTimeFormatter.ofPattern(DATE_FORMAT_ABBREVIATION)
-                .withLocale(Locale.ENGLISH);
-            case OFFSET_0000, OFFSET_0900 -> DateTimeFormatter.ofPattern(DATE_FORMAT_NUMERICAL)
-                .withLocale(Locale.ENGLISH);
-            default -> throw new IllegalStateException("Unexpected value: " + parsingDate);
-        };
+        for (DateTimeFormatter formatter : FORMATTERS) {
+            try {
+                return Instant.from(formatter.parse(parsingDate));
+            } catch (DateTimeParseException ignored) {
 
-        return Instant.from(formatter.parse(parsingDate));
+            }
+        }
+        throw new IllegalStateException("Unexpected value: " + parsingDate);
     }
 
     /**


### PR DESCRIPTION
## 🔑 Key Changes
- #96 리뷰 반영: pubDate 포맷 변환 로직 변경

## 👩‍💻 To Reviewers
> (p3:그냥 사소한 의견입니다) 타임존을 기준으로 포맷을 식별하시는데 그냥 바로 pattern 파싱 시도하고 예외 터지면 다른 pattern으로 파싱 시도하는 방식으로 하는 것은 어떤가요?
date 포맷은 배열[]이나 리스트, 셋같은걸로 저장하면 코드 가독성도 향상되고 포맷 배열을 관리하는 것도 편할 것 같아서요.
- 해당 리뷰 반영했습니다.
- ‼️ 머지할 때 base를 sprint로 변경해야 합니다.

## Related to
- Closes #107 
