### PR TITLE
Swagger 초기 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     // jsoup HTML parser library @ https://jsoup.org/
     implementation 'org.jsoup:jsoup:1.17.1'
+    // Swaager
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 test {

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/PostListReadController.java
@@ -2,6 +2,8 @@ package com.flytrap.rssreader.presentation.controller;
 
 import com.flytrap.rssreader.domain.folder.Folder;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.presentation.docs.post.GetPostsBySubscribeDocs;
+import com.flytrap.rssreader.presentation.docs.post.PostListReadControllerDocs;
 import com.flytrap.rssreader.presentation.dto.PostFilter;
 import com.flytrap.rssreader.presentation.dto.PostResponse;
 import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@PostListReadControllerDocs
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -26,6 +29,7 @@ public class PostListReadController {
     private final PostListReadService postListReadService;
     private final FolderVerifyOwnerService folderVerifyOwnerService;
 
+    @GetPostsBySubscribeDocs
     @GetMapping("/subscribes/{subscribeId}/posts")
     public ApplicationResponse<PostListResponse> getPostsBySubscribe(
             @PathVariable Long subscribeId,

--- a/src/main/java/com/flytrap/rssreader/presentation/docs/post/GetPostsBySubscribeDocs.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/docs/post/GetPostsBySubscribeDocs.java
@@ -1,0 +1,20 @@
+package com.flytrap.rssreader.presentation.docs.post;
+
+import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Operation(summary = "구독한 블로그의 게시글 목록 불러오기", description = "구독한 블로그의 게시글 목록을 반환한다.")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostListResponse.class))),
+})
+public @interface GetPostsBySubscribeDocs { }

--- a/src/main/java/com/flytrap/rssreader/presentation/docs/post/PostListReadControllerDocs.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/docs/post/PostListReadControllerDocs.java
@@ -1,0 +1,13 @@
+package com.flytrap.rssreader.presentation.docs.post;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Tag(name = "게시글 목록 불러오기")
+public @interface PostListReadControllerDocs { }
+


### PR DESCRIPTION
## 🔑 Key Changes
- Swagger 라이브러리를 추가
- 예시로 커스텀 어노테이션 하나 만들었습니다.

## 👩‍💻 To Reviewers
### 문서 예시
<img width="670" alt="image" src="https://github.com/Flytrap-Ware/RSS-Reader/assets/86359180/0a59663b-f700-4743-9fa5-ddec3992052f">
<img width="440" alt="image" src="https://github.com/Flytrap-Ware/RSS-Reader/assets/86359180/3a9d6154-eee0-4bab-83c0-0c6aac55a3a0">

### 기타
## **⚙️기타**
### 사용한 라이브러리
- Spring boot 3 버전 부터는 [SpringDoc OpenAPI Starter WebMVC UI](https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui) 사용
    - `{domain}/swagger-ui/index.html` 로 접속 가능

### 파라미터 설명
- 파라미터 설명도 넣고 싶었어요. 그러나 파라미터는 파라마터에 직접 어노테이션으로 붙여야 해서 코드가 지저분해 집니다.
- 예시 사진이랑, 코드 보시고 이대로 진행할지 다른 문서화 방법을 찾을지 논의해보면 좋을것 같아요

### ⚠️ 주의사항 ⚠️
- ‼️별로면 Merge하지 마시고 Close 해주세요

## Related to
- Closes #120 
