### PR TITLE
북마크 추가/제거 API 변경: 북마크 추가/제거 시 postId를 사용하도록 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/BookmarkEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/BookmarkEntityJpaRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkEntityJpaRepository extends JpaRepository<BookmarkEntity, Long> {
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
+    void deleteAllByMemberIdAndPostId(Long memberId, Long postId);
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
@@ -12,25 +12,12 @@ public interface PostOpenRepository extends JpaRepository<OpenEntity, Long> {
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
 
     @Query("select p.subscribe.id as subscribeId, count(o.postId) as postCount "
-            + "from OpenEntity o "
-            + "inner join PostEntity p on o.postId = p.id "
-            + "where o.memberId = :id and p.subscribe.id in :subscribes "
-            + "group by o.postId")
+        + "from OpenEntity o "
+        + "inner join PostEntity p on o.postId = p.id "
+        + "where o.memberId = :id and p.subscribe.id in :subscribes "
+        + "group by o.postId")
     List<OpenPostCount> countOpens(@Param("id") long id,
-            @Param("subscribes") List<Long> subscribes);
-
-    default Map<Long, Integer> countsGroupBySubscribeId(long id, List<Long> subscribes) {
-        List<OpenPostCount>resultList = countOpens(id, subscribes);
-
-        Map<Long, Integer> result = new HashMap<>();
-        for (OpenPostCount[] row : resultList) {
-            Long subscribeId = (Long) row[0];
-            Integer postCount = ((Number) row[1]).intValue(); // count(p)는 Number 타입이므로 적절한 형변환 필요
-            result.put(subscribeId, postCount);
-        }
-
-        return result;
-    }
+        @Param("subscribes") List<Long> subscribes);
 
     int deleteByMemberIdAndPostId(long memberId, Long postId);
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/BookmarkController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/BookmarkController.java
@@ -29,16 +29,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/bookmarks")
+@RequestMapping("/api")
 public class BookmarkController implements BookmarkControllerApi {
 
-    private static final String DELETE_BOOKMARK_MESSAGE = "북마크가 삭제되었습니다. : ";
+    private static final String DELETE_BOOKMARK_MESSAGE = "북마크가 삭제되었습니다. postId = ";
 
     private final PostService postService;
     private final BookmarkService bookmarkService;
     private final BookmarkVerifyOwnerService bookmarkVerifyOwnerService;
 
-    @GetMapping
+    @GetMapping("/bookmarks")
     public ApplicationResponse<PostListResponse> getBookmarks(
         PostFilter postFilter,
         @PageableDefault(page = 0, size = 15) Pageable pageable,
@@ -55,30 +55,28 @@ public class BookmarkController implements BookmarkControllerApi {
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping
+    @PostMapping("/posts/{postId}/bookmarks")
     public ApplicationResponse<BookmarkRequest.Response> addBookmark(
-        @RequestBody BookmarkRequest.CreateRequest request,
+        @PathVariable Long postId,
         @Login SessionMember member
     ) {
 
-        Post post = postService.findById(request.postId());
+        Post post = postService.findById(postId);
         Bookmark bookmark = bookmarkService.addBookmark(member, post);
 
         return new ApplicationResponse<>(BookmarkRequest.Response.from(bookmark));
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @DeleteMapping("/{bookmarkId}")
+    @DeleteMapping("/posts/{postId}/bookmarks")
     public ApplicationResponse<String> removeBookmark(
-        @PathVariable Long bookmarkId,
+        @PathVariable Long postId,
         @Login SessionMember member
     ) {
 
-        Bookmark bookmark = bookmarkVerifyOwnerService
-            .getVerifiedBookmark(member, bookmarkId);
-        bookmarkService.removeBookmark(bookmark);
+        bookmarkService.removeBookmark(member, postId);
 
-        return new ApplicationResponse<>(DELETE_BOOKMARK_MESSAGE + bookmark.getId());
+        return new ApplicationResponse<>(DELETE_BOOKMARK_MESSAGE + postId);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/BookmarkControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/BookmarkControllerApi.java
@@ -36,7 +36,7 @@ public interface BookmarkControllerApi {
         @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = BookmarkRequest.Response.class))),
     })
     ApplicationResponse<BookmarkRequest.Response> addBookmark(
-        @Parameter(description = "북마크에 추가할 게시글 ID") @RequestBody BookmarkRequest.CreateRequest request,
+        @Parameter(description = "북마크에 추가할 게시글 ID") @PathVariable Long postId,
         @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember member
     );
 
@@ -45,7 +45,7 @@ public interface BookmarkControllerApi {
         @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
     })
     ApplicationResponse<String> removeBookmark(
-        @Parameter(description = "제거할 북마크 ID") @PathVariable Long bookmarkId,
+        @Parameter(description = "북마크를 제거할 게시글 ID") @PathVariable Long postId,
         @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember member
     );
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/BookmarkRequest.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/BookmarkRequest.java
@@ -5,9 +5,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record BookmarkRequest() {
 
-    public record CreateRequest(@NotNull Long postId) {
-    }
-
     public record Response(Long id, Long memberId, Long postId) {
         public static Response from(Bookmark bookmark) {
             return new Response(bookmark.getId(), bookmark.getMemberId(), bookmark.getPostId());

--- a/src/main/java/com/flytrap/rssreader/service/BookmarkService.java
+++ b/src/main/java/com/flytrap/rssreader/service/BookmarkService.java
@@ -39,9 +39,9 @@ public class BookmarkService {
         return bookmarkRepository.save(BookmarkEntity.create(member.id(), post.getId())).toDomain();
     }
 
-    public void removeBookmark(Bookmark bookmark) {
+    public void removeBookmark(SessionMember member, Long postId) {
 
-        bookmarkRepository.delete(BookmarkEntity.from(bookmark));
+        bookmarkRepository.deleteAllByMemberIdAndPostId(member.id(), postId);
     }
 
     public boolean existBookmark(SessionMember member, Post post) {

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -14,6 +14,7 @@ VALUES (1, 4);
 
 INSERT INTO `folder_subscribe`(folder_id, subscribe_id, description)
 VALUES (1, 1, ''), (1, 2, ''),
+       (1, 5, ''), (1, 6, ''),
        (2, 1, ''), (2, 3, ''),
        (3, 4, ''), (4, 2, ''),
        (4, 5, ''), (4, 6, '');


### PR DESCRIPTION
## 🔑 Key Changes
- 북마크 추가/제거 API 변경: 북마크 추가/제거 시 postId를 사용하도록 변경

## 👩‍💻 To Reviewers
- 프론트 쪽에서 bookmarkId를 받고 있지 않아 postId로 북마크를 제거할 수 있도록 변경하고자 하였습니다.
  - 백엔드에서 게시글 리스트를 반환할 때 bookmark Id를 반환할 수 도 있지만, 이 경우 프론트에서도 상태 관리 로직이 추가되어야 해서 작업량이 많아집니다.
  - 따라서 API를 변경해 post id로 북마크를 제거할 수 있도록 하였습니다.
  - 북마크 제거 API가 변경됨에 따라 북마크 추가 API도 북마크 제거와 같은 양식으로 변경했습니다
- 동의하시면 postMan, Notion에도 제가 변경해 놓겠습니다.

### 북마크 추가
||메소드|API Path|Request Body|
|---|---|---|---|
|변경 전|`POST`|`/api/bookmarks`|`{"postId": postId}`|
|변경 후|`POST`|`/api/posts/{postId}/bookmarks`||

### 북마크 제거
||메소드|API Path|
|---|---|---|
|변경 전|`DELETE`|`/api/bookmarks/{bookmarkId}`|
|변경 후|`DELETE`|`/api/posts/{postId}/bookmarks`|

## Related to
- closes #137 
