### PR TITLE
사용자 조회가 여러건 일 경우, Duplicate Id Query Exception 수정

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostOpenRepository.java
@@ -2,7 +2,9 @@ package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.post.OpenEntity;
 import com.flytrap.rssreader.infrastructure.entity.post.OpenPostCount;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,22 +17,9 @@ public interface PostOpenRepository extends JpaRepository<OpenEntity, Long> {
             + "from OpenEntity o "
             + "inner join PostEntity p on o.postId = p.id "
             + "where o.memberId = :id and p.subscribe.id in :subscribes "
-            + "group by o.postId")
+            + "group by p.subscribe.id")
     List<OpenPostCount> countOpens(@Param("id") long id,
             @Param("subscribes") List<Long> subscribes);
-
-    default Map<Long, Integer> countsGroupBySubscribeId(long id, List<Long> subscribes) {
-        List<OpenPostCount>resultList = countOpens(id, subscribes);
-
-        Map<Long, Integer> result = new HashMap<>();
-        for (OpenPostCount[] row : resultList) {
-            Long subscribeId = (Long) row[0];
-            Integer postCount = ((Number) row[1]).intValue(); // count(p)는 Number 타입이므로 적절한 형변환 필요
-            result.put(subscribeId, postCount);
-        }
-
-        return result;
-    }
 
     int deleteByMemberIdAndPostId(long memberId, Long postId);
 }

--- a/src/main/java/com/flytrap/rssreader/service/folder/FolderSubscribeService.java
+++ b/src/main/java/com/flytrap/rssreader/service/folder/FolderSubscribeService.java
@@ -51,6 +51,6 @@ public class FolderSubscribeService {
 
         return folders.stream()
                 .collect(Collectors.toMap(folder -> folder,
-                        folder -> folderSubscribeIds.get(folder.getId())));
+                        folder -> folderSubscribeIds.getOrDefault(folder.getId(), List.of())));
     }
 }

--- a/src/test/java/com/flytrap/rssreader/service/PostOpenServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/PostOpenServiceTest.java
@@ -1,0 +1,106 @@
+package com.flytrap.rssreader.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.flytrap.rssreader.infrastructure.entity.post.OpenPostCount;
+import com.flytrap.rssreader.infrastructure.repository.PostOpenRepository;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PostOpenService 단위 테스트")
+class PostOpenServiceTest {
+
+    @Mock
+    PostOpenRepository postOpenRepository;
+    @InjectMocks
+    PostOpenService postOpenService;
+
+    @Nested
+    class open {
+
+    }
+
+    @Nested
+    class countOpens {
+
+        @Test
+        @DisplayName("countOpens 메서드는 구독자들의 포스트 오픈 횟수를 조회한다.")
+        void countOpens_shouldCountOpensOfSubscribers() {
+            // given
+            when(postOpenRepository.countOpens(anyLong(), anyList()))
+                    .thenReturn(List.of(new OpenPostCount() {
+                        @Override
+                        public long getSubscribeId() {
+                            return 1L;
+                        }
+
+                        @Override
+                        public int getPostCount() {
+                            return 3;
+                        }
+                    }));
+
+            // when
+            var result = postOpenService.countOpens(1L, List.of(1L));
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.get(1L).getPostCount()).isEqualTo(3);
+                softAssertions.assertThat(result).hasSize(1);
+            });
+        }
+
+        @Test
+        @DisplayName("사용자가 2개 블로그에서 포스트를 읽었을 경우, 블로그별로 오픈 횟수를 조회한다.")
+        void countOpens_shouldCountOpensOfSubscribersByBlog() {
+            // given
+            when(postOpenRepository.countOpens(anyLong(), anyList()))
+                    .thenReturn(List.of(new OpenPostCount() {
+                        @Override
+                        public long getSubscribeId() {
+                            return 1L;
+                        }
+
+                        @Override
+                        public int getPostCount() {
+                            return 3;
+                        }
+                    }, new OpenPostCount() {
+                        @Override
+                        public long getSubscribeId() {
+                            return 2L;
+                        }
+
+                        @Override
+                        public int getPostCount() {
+                            return 2;
+                        }
+                    }));
+
+            // when
+            var result = postOpenService.countOpens(1L, List.of(1L, 2L));
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.get(1L).getPostCount()).isEqualTo(3);
+                softAssertions.assertThat(result.get(2L).getPostCount()).isEqualTo(2);
+                softAssertions.assertThat(result).hasSize(2);
+            });
+        }
+    }
+
+    @Test
+    void deleteRead() {
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 쿼리 오류 수정

## 👩‍💻 To Reviewers
- 쿼리 오류 수정하였습니다
- `Null safe` 하도록 Map에서 `get` 메서드를 `getOrDefault` 로 수정하였습니다.

## Related to
- closes #139 
