### PR TITLE
구독 추가 API 수정 - 블로그 추가 성공시 블로그 정보를 반환하도록 수정

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/EmptyOpenPostCount.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/EmptyOpenPostCount.java
@@ -1,0 +1,14 @@
+package com.flytrap.rssreader.infrastructure.entity.post;
+
+public class EmptyOpenPostCount implements OpenPostCount {
+
+    @Override
+    public long getSubscribeId() {
+        return 0;
+    }
+
+    @Override
+    public int getPostCount() {
+        return 0;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/EmptySubscribePostCount.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/post/EmptySubscribePostCount.java
@@ -1,0 +1,14 @@
+package com.flytrap.rssreader.infrastructure.entity.post;
+
+public class EmptySubscribePostCount implements SubscribePostCount {
+
+    @Override
+    public long getSubscribeId() {
+        return 0;
+    }
+
+    @Override
+    public int getPostCount() {
+        return 0;
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.presentation.controller;
 
 import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
 import com.flytrap.rssreader.domain.subscribe.Subscribe;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.infrastructure.entity.alert.AlertPlatform;
@@ -9,6 +10,7 @@ import com.flytrap.rssreader.presentation.dto.AlertRequest;
 import com.flytrap.rssreader.presentation.dto.FolderRequest;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.dto.SubscribeRequest;
+import com.flytrap.rssreader.presentation.facade.OpenCheckFacade;
 import com.flytrap.rssreader.presentation.resolver.Login;
 import com.flytrap.rssreader.service.alert.AlertService;
 import com.flytrap.rssreader.service.folder.FolderSubscribeService;
@@ -16,11 +18,9 @@ import com.flytrap.rssreader.service.folder.FolderUpdateService;
 import com.flytrap.rssreader.service.folder.FolderVerifyOwnerService;
 import com.flytrap.rssreader.service.SubscribeService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,11 +39,12 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
     private final SubscribeService subscribeService;
     private final FolderSubscribeService folderSubscribeService;
     private final AlertService alertService;
+    private final OpenCheckFacade openCheckFacade;
 
     @PostMapping
     public ApplicationResponse<FolderRequest.Response> createFolder(
-            @Valid @RequestBody FolderRequest.CreateRequest request,
-            @Login SessionMember member) {
+        @Valid @RequestBody FolderRequest.CreateRequest request,
+        @Login SessionMember member) {
 
         Folder newFolder = folderService.createNewFolder(request, member.id());
 
@@ -52,9 +53,9 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
 
     @PatchMapping("/{folderId}")
     public ApplicationResponse<FolderRequest.Response> updateFolder(
-            @Valid @RequestBody FolderRequest.CreateRequest request,
-            @PathVariable Long folderId,
-            @Login SessionMember member) {
+        @Valid @RequestBody FolderRequest.CreateRequest request,
+        @PathVariable Long folderId,
+        @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         Folder updatedFolder = folderService.updateFolder(request, verifiedFolder, member.id());
@@ -65,8 +66,8 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{folderId}")
     public ApplicationResponse<String> deleteFolder(
-            @PathVariable Long folderId,
-            @Login SessionMember member) {
+        @PathVariable Long folderId,
+        @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         Folder folder = folderService.deleteFolder(verifiedFolder, member.id());
@@ -77,38 +78,42 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{folderId}/rss")
     public ApplicationResponse<SubscribeRequest.Response> subscribe(
-            @PathVariable Long folderId,
-            @Valid @RequestBody SubscribeRequest.CreateRequest request,
-            @Login SessionMember member) {
+        @PathVariable Long folderId,
+        @Valid @RequestBody SubscribeRequest.CreateRequest request,
+        @Login SessionMember member) {
         //TODO: 존재하는 폴더인지 검증하는 로직 , 공유폴더초대받은 인지 검증
         //TODO: 내가만든 폴더랑, 초대받은 그룹의 폴더인지 구분해서 구독해야합니다.
         //지금 부분은 검증된 개인 폴더입니다.
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         Subscribe subscribe = subscribeService.subscribe(request);
         folderSubscribeService.folderSubscribe(subscribe,
-                verifiedFolder.getId());
-        return new ApplicationResponse<>(SubscribeRequest.Response.from(subscribe));
+            verifiedFolder.getId());
+
+        FolderSubscribe folderSubscribe = FolderSubscribe.from(subscribe);
+        folderSubscribe = openCheckFacade.addUnreadCountInFolderSubscribe(member.id(), subscribe, folderSubscribe);
+
+        return new ApplicationResponse<>(SubscribeRequest.Response.from(folderSubscribe));
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{folderId}/rss/{subscribeId}")
     public ApplicationResponse<Void> unsubscribe(
-            @PathVariable Long folderId,
-            @PathVariable Long subscribeId,
-            @Login SessionMember member) {
+        @PathVariable Long folderId,
+        @PathVariable Long subscribeId,
+        @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         subscribeService.unsubscribe(subscribeId);
         folderSubscribeService.folderUnsubscribe(subscribeId,
-                verifiedFolder.getId());
+            verifiedFolder.getId());
         return new ApplicationResponse<>(null);
     }
 
     @PostMapping("/{folderId}/alerts")
     public ApplicationResponse<Long> onAlert(
-            @PathVariable Long folderId,
-            @Valid @RequestBody AlertRequest request,
-            @Login SessionMember member) {
+        @PathVariable Long folderId,
+        @Valid @RequestBody AlertRequest request,
+        @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         AlertPlatform.ofCode(request.platformNum());
@@ -118,8 +123,8 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
 
     @DeleteMapping("/{folderId}/alerts ")
     public ApplicationResponse<Void> offAlert(
-            @PathVariable Long folderId,
-            @Login SessionMember member) {
+        @PathVariable Long folderId,
+        @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         alertService.off(verifiedFolder.getId(), member.id());

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/FolderUpdateControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/FolderUpdateControllerApi.java
@@ -7,6 +7,12 @@ import com.flytrap.rssreader.presentation.dto.FolderRequest.Response;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.dto.SubscribeRequest;
 import com.flytrap.rssreader.presentation.resolver.Login;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,11 +35,14 @@ public interface FolderUpdateControllerApi {
         @PathVariable Long folderId,
         @Login SessionMember member);
 
-    // TODO: Swaager 어노테이션 붙여주세요.
+    @Operation(summary = "폴더에 블로그 추가하기(블로그 구독하기)", description = "이미 추가된 폴더에 블로그를 새로 추가한다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "블로그 추가 성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = SubscribeRequest.Response.class))),
+    })
     ApplicationResponse<SubscribeRequest.Response> subscribe(
-        @PathVariable Long folderId,
-        @Valid @RequestBody SubscribeRequest.CreateRequest request,
-        @Login SessionMember member);
+        @Parameter(description = "블로그를 추가할 폴더의 ID") @PathVariable Long folderId,
+        @Parameter(description = "추가할 블로그의 주소") @Valid @RequestBody SubscribeRequest.CreateRequest request,
+        @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember member);
 
     // TODO: Swaager 어노테이션 붙여주세요.
     ApplicationResponse<Void> unsubscribe(

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/SubscribeRequest.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/SubscribeRequest.java
@@ -1,5 +1,6 @@
 package com.flytrap.rssreader.presentation.dto;
 
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
 import com.flytrap.rssreader.domain.subscribe.Subscribe;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -13,11 +14,12 @@ public record SubscribeRequest() {
 
     }
 
-    public record Response(Long subscribeId) {
+    public record Response(Long subscribeId, String subscribeTitle, Integer unreadCount) {
 
         public static SubscribeRequest.Response from(
-                Subscribe subscribe) {
-            return new SubscribeRequest.Response(subscribe.getId());
+            FolderSubscribe folderSubscribe) {
+            return new SubscribeRequest.Response(folderSubscribe.getId(),
+                folderSubscribe.getTitle(), folderSubscribe.getUnreadCount());
         }
     }
 

--- a/src/main/java/com/flytrap/rssreader/presentation/facade/OpenCheckFacade.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/facade/OpenCheckFacade.java
@@ -1,6 +1,10 @@
 package com.flytrap.rssreader.presentation.facade;
 
 import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
+import com.flytrap.rssreader.domain.subscribe.Subscribe;
+import com.flytrap.rssreader.infrastructure.entity.post.EmptyOpenPostCount;
+import com.flytrap.rssreader.infrastructure.entity.post.EmptySubscribePostCount;
 import com.flytrap.rssreader.infrastructure.entity.post.OpenPostCount;
 import com.flytrap.rssreader.infrastructure.entity.post.SubscribePostCount;
 import com.flytrap.rssreader.service.PostOpenService;
@@ -17,10 +21,24 @@ public class OpenCheckFacade {
     private final PostReadService postReadService;
     private final PostOpenService postOpenService;
 
+    public FolderSubscribe addUnreadCountInFolderSubscribe(long memberId, Subscribe subscribe,
+        FolderSubscribe folderSubscribe) {
+        Long subscribeId = subscribe.getId();
+        Map<Long, SubscribePostCount> countsPost = postReadService.countPosts(List.of(subscribeId));
+        Map<Long, OpenPostCount> countsOpen = postOpenService.countOpens(memberId,
+            List.of(subscribeId));
 
-    public List<? extends Folder> addUnreadCountInSubscribes(long id, List<? extends Folder> foldersWithSubscribe) {
+        folderSubscribe.addUnreadCount(
+            countsPost.getOrDefault(subscribeId, new EmptySubscribePostCount()).getPostCount(),
+            countsOpen.getOrDefault(subscribeId, new EmptyOpenPostCount()).getPostCount());
+
+        return folderSubscribe;
+    }
+
+    public List<? extends Folder> addUnreadCountInSubscribes(long id,
+        List<? extends Folder> foldersWithSubscribe) {
         List<Long> subscribes = foldersWithSubscribe.stream().map(Folder::getSubscribeIds)
-                .flatMap(List::stream).toList();
+            .flatMap(List::stream).toList();
 
         Map<Long, SubscribePostCount> countsPost = postReadService.countPosts(subscribes);
         Map<Long, OpenPostCount> countsOpen = postOpenService.countOpens(id, subscribes);


### PR DESCRIPTION
## 🔑 Key Changes
- 구독 추가 API 수정 - 블로그 추가 성공시 블로그 정보를 반환하도록 수정
  - 구독 추가 성공 후 블로그 id, title, unreadCount 까지 같이 반환하도록 수정
  - 구독 추가 성공 후 블로그 제목을 반환해줘야 프론트에서 새로고침 없이 화면에 띄어줄 수 있어서 필요함

## 👩‍💻 To Reviewers

### 수정 전 구독 추가 API
```json
{
    "data": {
        "subscribeId": 1,
    }
}
```

### 수정 후 구독 추가 API
```json
{
    "data": {
        "subscribeId": 1,
        "subscribeTitle": "조금씩, 꾸준히, 자주",
        "unreadCount": 20
    }
}
```
- 반환되는 subscribeId는 실제 subscribe가 이닌 folderSubscribe의 id로 변경했습니다.
  - 구독을 추가 후 유저가 볼 수 있는 게 subscribe가 아닌 폴더별로 저장된 블로그(folderSubscribe)이기 때문에 folderSubscribe의 id가 필요해서 변경했습니다.

## Related to
- Closes #143 
