### PR TITLE
폴더에 회원 초대하기 API 수정 - 추가 성공시 회원 정보를 반환하도록 수정

### DIFF
--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -5,6 +5,7 @@ import com.flytrap.rssreader.domain.member.Member;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.controller.api.SharedFolderUpdateControllerApi;
 import com.flytrap.rssreader.presentation.dto.InviteMemberRequest;
+import com.flytrap.rssreader.presentation.dto.MemberSummary;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.resolver.Login;
 import com.flytrap.rssreader.service.folder.FolderUpdateService;
@@ -34,7 +35,7 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{folderId}/members")
-    public ApplicationResponse inviteMember(
+    public ApplicationResponse<MemberSummary> inviteMember(
             @PathVariable Long folderId,
             @Login SessionMember loginMember,
             @RequestBody InviteMemberRequest request
@@ -45,7 +46,7 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
         Member member = memberService.findById(request.inviteeId());
         sharedFolderService.invite(verifiedFolder, member.getId());
 
-        return ApplicationResponse.success("멤버가 초대되었습니다 : " + request.inviteeId());
+        return new ApplicationResponse<>(MemberSummary.from(member));
     }
 
     // 공유 폴더에 사람 나가기 (내가 스스로 나간다)

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/SharedFolderUpdateControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/SharedFolderUpdateControllerApi.java
@@ -2,19 +2,31 @@ package com.flytrap.rssreader.presentation.controller.api;
 
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.InviteMemberRequest;
+import com.flytrap.rssreader.presentation.dto.MemberSummary;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.resolver.Login;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.security.sasl.AuthenticationException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name ="공유 폴더")
 public interface SharedFolderUpdateControllerApi {
 
-    // TODO: Swaager 어노테이션 붙여주세요.
-    ApplicationResponse inviteMember(
-        @PathVariable Long folderId,
-        @Login SessionMember loginMember,
-        @RequestBody InviteMemberRequest request
+    @Operation(summary = "폴더에 회원 초대", description = "폴더에 회원을 한명 초대한다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberSummary.class))),
+    })
+    ApplicationResponse<MemberSummary> inviteMember(
+        @Parameter(description = "회원을 초대할 폴더의 ID") @PathVariable Long folderId,
+        @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember loginMember,
+        @Parameter(description = "초대할 회원의 ID") @RequestBody InviteMemberRequest request
     ) throws AuthenticationException;
 
     // TODO: Swaager 어노테이션 붙여주세요.


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더에 회원 초대하기 API 수정 - 추가 성공시 회원 정보를 반환하도록 수정
  - 회원 초대 성공 후 회원 이름, 프로필 이미지 주소를 추가로 반환하도록 수정
  - 회원 초대 성공 후 회원 정보를 프론트에서 새로고침 없이 화면에 띄어줄 때 필요함

## 👩‍💻 To Reviewers

### 수정 전 멤버 추가 API
```json
{
    "data": "멤버가 초대되었습니다 : 2"
}
```

### 수정 후 멤버 추가 API
```json
{
    "data": {
        "id": 2,
        "name": "test01",
        "profile": "https://avatars.githubusercontent.com/u/86359180?v=4"
    }
}
```

## Related to
- Closes #145 
