### PR TITLE
폴더 목록 불러오기 API 수정 - 공유 폴더에 구독 블로그가 누락된 채로 폴더 목록이 반환되는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/shared/SharedFolder.java
+++ b/src/main/java/com/flytrap/rssreader/domain/shared/SharedFolder.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.domain.shared;
 
 import com.flytrap.rssreader.domain.folder.Folder;
+import com.flytrap.rssreader.domain.folder.FolderSubscribe;
 import com.flytrap.rssreader.domain.member.Member;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,8 +10,9 @@ public class SharedFolder extends Folder {
 
     private List<Member> invitedMembers = new ArrayList<>();
 
-    protected SharedFolder(Long id, String name, Long memberId, Boolean isDeleted, List<Member> invitedMembers) {
+    protected SharedFolder(Long id, String name, Long memberId, Boolean isDeleted, List<Member> invitedMembers, List<FolderSubscribe> subscribes) {
         super(id, name, memberId, true, isDeleted);
+        super.addAllSubscribes(subscribes);
         this.invitedMembers = invitedMembers;
     }
 
@@ -23,7 +25,7 @@ public class SharedFolder extends Folder {
     }
 
     public static SharedFolder of (Folder folder, List<Member> invitedMembers) {
-        return new SharedFolder(folder.getId(), folder.getName(), folder.getMemberId(), folder.getIsDeleted(), invitedMembers);
+        return new SharedFolder(folder.getId(), folder.getName(), folder.getMemberId(), folder.getIsDeleted(), invitedMembers, folder.getSubscribes());
     }
 
 }


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더 목록 불러오기 API 수정 - 공유 폴더에 구독 블로그가 누락된 채로 폴더 목록이 반환되는 문제 해결

## 👩‍💻 To Reviewers
### 문제 원인
- Folder에 초대된 멤버 정보를 주입할 때 블로그가 누락된 채로 새로운 Folder를 생성하고 있어서 생긴 문제

## Related to
- Closed #147 
