### PR TITLE
폴더에 멤버 추가하기 API 수정 - 폴더 소유자 초대 실패 시 개인 폴더가 공유폴더로 바뀌는 문제

### DIFF
--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -42,9 +42,9 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
     ) throws AuthenticationException {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, loginMember.id());
-        folderUpdateService.shareFolder(verifiedFolder);
         Member member = memberService.findById(request.inviteeId());
         sharedFolderService.invite(verifiedFolder, member.getId());
+        folderUpdateService.shareFolder(verifiedFolder);
 
         return new ApplicationResponse<>(MemberSummary.from(member));
     }


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더 소유자 초대 실패 시 개인 폴더가 공유폴더로 바뀌는 문제 해결

## 👩‍💻 To Reviewers
### 폴더 소유자 초대 실패 시 개인 폴더가 공유폴더로 바뀌는 문제
  - 폴더 소유자가 자기 자신을 초대할 수 없어야 한다.
  - 수정 전) 폴더 소유자가 자기 자신을 초대한 경우 초대에 실패하지만, 개인 폴더가 공유폴더로 변경되는 문제가 있었다.
  - 원인) 회원 초대 기능 수행 시 폴더를 공유 폴더로 변경한 후에 회원을 검증하고 있어서 생긴 문제
  - 해결) 폴더에 초대할 회원을 먼저 검증하고 폴더를 공유 폴더로 변경하도록 변경해서 해결

## Related to
- Closes #150 
