### PR TITLE
폴더에 멤버 삭제하기 API 수정 - 폴더에 구독한 블로그 삭제할 때 rss_subscribe도 같이 삭제하는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -103,7 +103,6 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
         @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
-        subscribeService.unsubscribe(subscribeId);
         folderSubscribeService.folderUnsubscribe(subscribeId,
             verifiedFolder.getId());
         return new ApplicationResponse<>(null);

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -42,9 +42,9 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
     ) throws AuthenticationException {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, loginMember.id());
-        folderUpdateService.shareFolder(verifiedFolder);
         Member member = memberService.findById(request.inviteeId());
         sharedFolderService.invite(verifiedFolder, member.getId());
+        folderUpdateService.shareFolder(verifiedFolder);
 
         return new ApplicationResponse<>(MemberSummary.from(member));
     }


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더에 구독한 블로그 삭제할 때 rss_subscribe도 같이 삭제하는 문제 해결

## 👩‍💻 To Reviewers
### 폴더에 구독한 블로그(folder_subscribe) 삭제할 때 rss_subscribe도 같이 삭제하는 문제 해결

## Related to
- Closes #151 
