### PR TITLE
폴더에서 멤버 삭제하기 API 수정 - 공유 폴더에서 멤버 모두를 추방 해도 여전히 공유폴더로 남아있는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/folder/Folder.java
+++ b/src/main/java/com/flytrap/rssreader/domain/folder/Folder.java
@@ -73,6 +73,10 @@ public class Folder implements DefaultDomain {
         this.sharedStatus = SharedStatus.SHARED;
     }
 
+    public void toPrivate() {
+        this.sharedStatus = SharedStatus.PRIVATE;
+    }
+
     public boolean isOwner(long id) {
         return this.memberId == id;
     }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -103,7 +103,6 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
         @Login SessionMember member) {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
-        subscribeService.unsubscribe(subscribeId);
         folderSubscribeService.folderUnsubscribe(subscribeId,
             verifiedFolder.getId());
         return new ApplicationResponse<>(null);

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -51,24 +51,28 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
 
     // 공유 폴더에 사람 나가기 (내가 스스로 나간다)
     @DeleteMapping("/{folderId}/members/me")
-    public ApplicationResponse leaveFolder(
+    public ApplicationResponse<String> leaveFolder(
             @PathVariable Long folderId,
             @Login SessionMember member
     ) {
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         sharedFolderService.leave(verifiedFolder, member.id());
+        folderUpdateService.toPrivate(verifiedFolder);
+
         return ApplicationResponse.success();
     }
 
     //공유 폴더에 사람 삭제하기 (만든 사람만)
     @DeleteMapping("/{folderId}/members/{inviteeId}")
-    public ApplicationResponse deleteMember(
+    public ApplicationResponse<String> deleteMember(
             @PathVariable Long folderId,
             @PathVariable Long inviteeId,
             @Login SessionMember member
     ) throws AuthenticationException {
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         sharedFolderService.removeFolderMember(verifiedFolder, inviteeId, member.id());
+        folderUpdateService.toPrivate(verifiedFolder);
+
         return ApplicationResponse.success();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -42,9 +42,9 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
     ) throws AuthenticationException {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, loginMember.id());
-        folderUpdateService.shareFolder(verifiedFolder);
         Member member = memberService.findById(request.inviteeId());
         sharedFolderService.invite(verifiedFolder, member.getId());
+        folderUpdateService.shareFolder(verifiedFolder);
 
         return new ApplicationResponse<>(MemberSummary.from(member));
     }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/SharedFolderUpdateControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/SharedFolderUpdateControllerApi.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.presentation.controller.api;
 
 import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.global.model.ErrorResponse;
 import com.flytrap.rssreader.presentation.dto.InviteMemberRequest;
 import com.flytrap.rssreader.presentation.dto.MemberSummary;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
@@ -22,6 +23,8 @@ public interface SharedFolderUpdateControllerApi {
     @Operation(summary = "폴더에 회원 초대", description = "폴더에 회원을 한명 초대한다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberSummary.class))),
+        @ApiResponse(responseCode = "400", description = "실패: 이미 초대되어 있을 때",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "실패: 초대 권한이 없을 때",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
     })
     ApplicationResponse<MemberSummary> inviteMember(
         @Parameter(description = "회원을 초대할 폴더의 ID") @PathVariable Long folderId,
@@ -29,16 +32,24 @@ public interface SharedFolderUpdateControllerApi {
         @Parameter(description = "초대할 회원의 ID") @RequestBody InviteMemberRequest request
     ) throws AuthenticationException;
 
-    // TODO: Swaager 어노테이션 붙여주세요.
-    ApplicationResponse leaveFolder(
-        @PathVariable Long folderId,
-        @Login SessionMember member
+    @Operation(summary = "초대된 폴더에서 떠나기", description = "내가 초대된 폴더에서 스스로 나간다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+    })
+    ApplicationResponse<String> leaveFolder(
+        @Parameter(description = "떠나고자 하는 폴더의 ID") @PathVariable Long folderId,
+        @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember member
     );
 
-    // TODO: Swaager 어노테이션 붙여주세요.
-    ApplicationResponse deleteMember(
-        @PathVariable Long folderId,
-        @PathVariable Long inviteeId,
-        @Login SessionMember member
+    @Operation(summary = "공유 폴더에 포함된 한 회원 추방하기", description = "공유 폴더에 포함된 한 회원 추방한다. 폴더 관리자만 추방할 수 있다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+        @ApiResponse(responseCode = "400", description = "실패: 폴더에 추가되어있지 않은 멤버 삭제할 때",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "실패: 추방 권한이 없을 때",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    ApplicationResponse<String> deleteMember(
+        @Parameter(description = "추방이 일어날 폴더의 ID") @PathVariable Long folderId,
+        @Parameter(description = "현재 폴더에서 추방시킬 회원의 ID") @PathVariable Long inviteeId,
+        @Parameter(description = "현재 로그인한 회원 정보") @Login SessionMember member
     ) throws AuthenticationException;
 }

--- a/src/main/java/com/flytrap/rssreader/service/folder/FolderUpdateService.java
+++ b/src/main/java/com/flytrap/rssreader/service/folder/FolderUpdateService.java
@@ -45,4 +45,11 @@ public class FolderUpdateService {
             repository.save(FolderEntity.from(folder));
         }
     }
+
+    public void toPrivate(Folder folder) {
+        if (folder.isShared()) {
+            folder.toPrivate();
+            repository.save(FolderEntity.from(folder));
+        }
+    }
 }


### PR DESCRIPTION
## 🔑 Key Changes
- 공유 폴더에서 멤버 모두를 추방 해도 여전히 공유폴더로 남아있는 문제 해결

## 👩‍💻 To Reviewers
### 공유 폴더에서 멤버 모두를 추방 해도 여전히 공유폴더로 남아있는 문제 해결
- 폴더에 초대된 멤버가 없으면 개인폴더로 취급해야한다.
- 수정 전) 현재 공유 폴더에 초대된 멤버를 모두 추방해도 rss_folder 테이블의 is_shared 컬럼의 값이 true로 남아있었다.
- 해결) `SharedFolderUpdateController.deleteMember()`, `SharedFolderUpdateController.leaveFolder()`에 공유 폴더를 개인 폴더로 변경하는 로직 추가

## Related to
- Closes #152 
