### PR TITLE
로그인시 반환되는 회원정보 추가 및 간단한 로그인 버그 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/member/Member.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/Member.java
@@ -2,7 +2,6 @@ package com.flytrap.rssreader.domain.member;
 
 import com.flytrap.rssreader.global.model.DefaultDomain;
 import com.flytrap.rssreader.global.model.Domain;
-import java.io.Serializable;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,11 +45,12 @@ public class Member implements DefaultDomain {
                 .build();
     }
 
-    public static Member adminOf(long userId, String userName, String userEmail) {
+    public static Member adminOf(long userId, String userName, String userEmail, String profile) {
         return Member.builder()
                 .id(userId)
                 .name(userName)
                 .email(userEmail)
+                .profile(profile)
                 .build();
     }
 

--- a/src/main/java/com/flytrap/rssreader/infrastructure/properties/AdminProperties.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/properties/AdminProperties.java
@@ -7,9 +7,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AdminProperties(String code,
                               int memberId,
                               String memberName,
-                              String memberEmail) {
+                              String memberEmail,
+                              String memberProfile) {
 
     public Member getMember() {
-        return Member.adminOf(memberId, memberName, memberEmail);
+        return Member.adminOf(memberId, memberName, memberEmail, memberProfile);
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/AdminController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/AdminController.java
@@ -1,9 +1,11 @@
 package com.flytrap.rssreader.presentation.controller;
 
+import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.infrastructure.properties.AdminProperties;
 import com.flytrap.rssreader.infrastructure.properties.AuthProperties;
 import com.flytrap.rssreader.presentation.controller.api.AdminControllerApi;
 import com.flytrap.rssreader.presentation.dto.Login;
+import com.flytrap.rssreader.presentation.dto.LoginResponse;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import jakarta.servlet.http.HttpSession;
 import javax.security.sasl.AuthenticationException;
@@ -27,12 +29,20 @@ public class AdminController implements AdminControllerApi {
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.CREATED)
-    public void getAdminProperties(@RequestBody Login request, HttpSession session)
+    public ApplicationResponse<LoginResponse> getAdminProperties(@RequestBody Login request, HttpSession session)
             throws AuthenticationException {
 
         if (request.code().equals(properties.code())) {
             session.setAttribute(authProperties.sessionId(), SessionMember.from(properties.getMember()));
             log.info("🙌 admin login success");
+
+            return new ApplicationResponse<>(
+                new LoginResponse(
+                    properties.memberId(),
+                    properties.memberName(),
+                    properties.memberProfile()
+                )
+            );
         } else {
             throw new AuthenticationException("admin login fail");
         }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/AuthController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/AuthController.java
@@ -4,7 +4,7 @@ import com.flytrap.rssreader.domain.member.Member;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.controller.api.AuthControllerApi;
 import com.flytrap.rssreader.presentation.dto.Login;
-import com.flytrap.rssreader.presentation.dto.SessionMember;
+import com.flytrap.rssreader.presentation.dto.LoginResponse;
 import com.flytrap.rssreader.service.AuthService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -24,12 +24,13 @@ public class AuthController implements AuthControllerApi {
 
     @Override
     @PostMapping("/login")
-    public ApplicationResponse<SessionMember> login(@RequestBody Login request,
+    public ApplicationResponse<LoginResponse> login(@RequestBody Login request,
             HttpSession session) {
 
         Member member = authService.doAuthentication(request);
+        authService.login(member, session);
 
-        return new ApplicationResponse<>(authService.login(member, session));
+        return new ApplicationResponse<>(LoginResponse.from(member));
     }
 
     @Override

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/AdminControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/AdminControllerApi.java
@@ -1,6 +1,8 @@
 package com.flytrap.rssreader.presentation.controller.api;
 
+import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.Login;
+import com.flytrap.rssreader.presentation.dto.LoginResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpSession;
 import javax.security.sasl.AuthenticationException;
@@ -9,6 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface AdminControllerApi {
 
     @Hidden
-    void getAdminProperties(@RequestBody Login request, HttpSession session)
+    ApplicationResponse<LoginResponse> getAdminProperties(@RequestBody Login request, HttpSession session)
         throws AuthenticationException;
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/AuthControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/AuthControllerApi.java
@@ -3,14 +3,25 @@ package com.flytrap.rssreader.presentation.controller.api;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.Login;
 import com.flytrap.rssreader.presentation.dto.LoginResponse;
+import com.flytrap.rssreader.presentation.dto.PostResponse.PostListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface AuthControllerApi {
 
-    // TODO: Swaager 어노테이션 붙여주세요.
-    ApplicationResponse<LoginResponse> login(@RequestBody Login request,
-        HttpSession session);
+    @Operation(summary = "로그인 및 회원가입", description = "OAuth 인증 후 반환받은 code로 로그인할 수 있다. 처음 로그인한 회원은 회원 가입과 로그인을 같이 수행한다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class))),
+    })
+    ApplicationResponse<LoginResponse> login(
+        @Parameter(description = "OAuth 인증 후 반환받은 code") @RequestBody Login request,
+        @Parameter(description = "로그인시 세션 생성에 사용할 HttpSession") HttpSession session);
 
     // TODO: Swaager 어노테이션 붙여주세요.
     ApplicationResponse<Void> logout(HttpSession session);

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/api/AuthControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/api/AuthControllerApi.java
@@ -2,14 +2,14 @@ package com.flytrap.rssreader.presentation.controller.api;
 
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.presentation.dto.Login;
-import com.flytrap.rssreader.presentation.dto.SessionMember;
+import com.flytrap.rssreader.presentation.dto.LoginResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface AuthControllerApi {
 
     // TODO: Swaager 어노테이션 붙여주세요.
-    ApplicationResponse<SessionMember> login(@RequestBody Login request,
+    ApplicationResponse<LoginResponse> login(@RequestBody Login request,
         HttpSession session);
 
     // TODO: Swaager 어노테이션 붙여주세요.

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.flytrap.rssreader.presentation.dto;
+
+import com.flytrap.rssreader.domain.member.Member;
+
+public record LoginResponse(
+    long id,
+    String name,
+    String profile
+) {
+
+    public static LoginResponse from(Member member) {
+        return new LoginResponse(member.getId(), member.getName(), member.getProfile());
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/filter/AuthenticationFilter.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/filter/AuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.flytrap.rssreader.presentation.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flytrap.rssreader.domain.member.Member;
 import com.flytrap.rssreader.infrastructure.properties.AuthProperties;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.resolver.AuthorizationContext;
@@ -11,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
-import javax.security.sasl.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
@@ -29,10 +26,13 @@ public class AuthenticationFilter extends OncePerRequestFilter { //TODO 통합�
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-            FilterChain chain) throws IOException, ServletException {
-        HttpSession session = request.getSession(true);
+        FilterChain chain) throws IOException, ServletException {
 
-        SessionMember attribute = (SessionMember) session.getAttribute(authProperties.sessionId());
+        HttpSession session = request.getSession(false);
+
+        SessionMember attribute = (session != null)
+            ? (SessionMember) session.getAttribute(authProperties.sessionId())
+            : null;
         context.setLoginMember(attribute);
 
         chain.doFilter(request, response);

--- a/src/main/java/com/flytrap/rssreader/presentation/filter/ExceptionHandleFilter.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/filter/ExceptionHandleFilter.java
@@ -10,7 +10,6 @@ import javax.security.sasl.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,8 +26,9 @@ public class ExceptionHandleFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (AuthenticationException e) {
             log.error(e.getMessage());
-            response.getWriter().println(ErrorResponse.occur("login", e).toString());
-            response.setHeader(HttpHeaders.ACCEPT_CHARSET, "utf-8");
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().println(ErrorResponse.occur("login", e));
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/flytrap/rssreader/service/AuthService.java
+++ b/src/main/java/com/flytrap/rssreader/service/AuthService.java
@@ -25,9 +25,8 @@ public class AuthService {
                 .block();
     }
 
-    public SessionMember login(Member member, HttpSession session) {
+    public void login(Member member, HttpSession session) {
         session.setAttribute(authProperties.sessionId(), SessionMember.from(member));
-        return SessionMember.from(member);
     }
 
     public void logout(HttpSession session) {


### PR DESCRIPTION
# 🔑 Key Changes
## 로그인시 반환되는 회원정보 추가
  - 변경 이유) 프론트 단에서 회원 정보(e.g. 프로필 사진) 등을 표시하기 위함
  - 수정 전) 로그인 시 회원의 id 값만 만환
  - 수정 후) 회원의 id, name, profile 정보를 반환하도록 수정

## ⚠️⚠️⚠️ Submodule 수정 있습니다 ⚠️⚠️⚠️
- 어드민 로그인은 `git submodule update` 반드시 해줘야 작동합니다.

# 👩‍💻 To Reviewers
- 간단한 버그 해결

## 회원 인증 에러 반환시 에러 메시지를 인코딩 하지 못하는 문제 해결
### 변경 전
```json
{
    "errorCode": "login",
    "message": "???? ????????"
}
```
### 변경 후
```json
{
    "errorCode": "login",
    "message": "로그인이 필요한 기능입니다."
}
```

### 해결 방법
- 에러 반환 시 Content-Type과 인코딩 설정 추가하여 해결

## 로그인 안된 상태에서 값이 없는 빈 session을 생성하는 버그 해결
### 쿠키가 없는 상태에서 로그인이 필요한 API에 접근했을 때 생성되는 빈 session
<img width="778" alt="image" src="https://github.com/FlytrapHub/RSS-Reader/assets/86359180/75fbb42b-2813-424d-9198-ae4d5684cafa">

### 정상적인 로그인 세션
<img width="770" alt="image" src="https://github.com/FlytrapHub/RSS-Reader/assets/86359180/c564f0d0-5a88-4824-b579-fc895522acda">
- 로그인이 성공한 경우에만 회원 정보 세션(blur 처리된 부분)이 있어야 한다.

### 원인과 해결
- 회원 검증 필터에서 `request.getSession(true);`를 사용해 세션이 없는 경우에도 새로운 세션을 생성하게 되어 생긴 버그
- `request.getSession(false);`로 변경하여 해결

## Related to
- Closes #157 
