### PR TITLE
폴더 멤버 제거, 폴더 떠나기 후 멤버가 남아 있어도 개인 폴더로 변환되는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/SharedFolderJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/SharedFolderJpaRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SharedFolderJpaRepository extends JpaRepository<SharedFolderEntity, Long> {
 
+    long countAllByFolderId(long folderId);
+
     List<SharedFolderEntity> findAllByFolderId(long folderId);
 
     boolean existsByFolderIdAndMemberId(long folderId, long memberId);

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/SharedFolderUpdateController.java
@@ -8,6 +8,7 @@ import com.flytrap.rssreader.presentation.dto.InviteMemberRequest;
 import com.flytrap.rssreader.presentation.dto.MemberSummary;
 import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.resolver.Login;
+import com.flytrap.rssreader.service.SharedFolderReadService;
 import com.flytrap.rssreader.service.folder.FolderUpdateService;
 import com.flytrap.rssreader.service.folder.FolderVerifyOwnerService;
 import com.flytrap.rssreader.service.MemberService;
@@ -28,7 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/folders")
 public class SharedFolderUpdateController implements SharedFolderUpdateControllerApi {
 
-    private final SharedFolderUpdateService sharedFolderService;
+    private final SharedFolderReadService sharedFolderReadService;
+    private final SharedFolderUpdateService sharedFolderUpdateService;
     private final FolderUpdateService folderUpdateService;
     private final FolderVerifyOwnerService folderVerifyOwnerService;
     private final MemberService memberService;
@@ -43,7 +45,7 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, loginMember.id());
         Member member = memberService.findById(request.inviteeId());
-        sharedFolderService.invite(verifiedFolder, member.getId());
+        sharedFolderUpdateService.invite(verifiedFolder, member.getId());
         folderUpdateService.shareFolder(verifiedFolder);
 
         return new ApplicationResponse<>(MemberSummary.from(member));
@@ -56,8 +58,12 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
             @Login SessionMember member
     ) {
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
-        sharedFolderService.leave(verifiedFolder, member.id());
-        folderUpdateService.makePrivate(verifiedFolder);
+        
+        sharedFolderUpdateService.leave(verifiedFolder, member.id());
+
+        if (sharedFolderReadService.countAllMembersByFolder(folderId) <= 0) {
+            folderUpdateService.makePrivate(verifiedFolder);
+        }
 
         return ApplicationResponse.success();
     }
@@ -70,8 +76,12 @@ public class SharedFolderUpdateController implements SharedFolderUpdateControlle
             @Login SessionMember member
     ) throws AuthenticationException {
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
-        sharedFolderService.removeFolderMember(verifiedFolder, inviteeId, member.id());
-        folderUpdateService.makePrivate(verifiedFolder);
+
+        sharedFolderUpdateService.removeFolderMember(verifiedFolder, inviteeId, member.id());
+
+        if (sharedFolderReadService.countAllMembersByFolder(folderId) <= 0) {
+            folderUpdateService.makePrivate(verifiedFolder);
+        }
 
         return ApplicationResponse.success();
     }

--- a/src/main/java/com/flytrap/rssreader/service/SharedFolderReadService.java
+++ b/src/main/java/com/flytrap/rssreader/service/SharedFolderReadService.java
@@ -16,6 +16,11 @@ public class SharedFolderReadService {
 
     private final SharedFolderJpaRepository sharedFolderJpaRepository;
 
+    @Transactional(readOnly = true)
+    public long countAllMembersByFolder(long folderId) {
+        return sharedFolderJpaRepository.countAllByFolderId(folderId);
+    }
+
     /**
      * 멤버Id로 초대된 폴더Id 목록을 반환합니다.
      * @param memberId


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더 멤버 제거, 폴더 떠나기 후 멤버가 남아 있어도 개인 폴더로 변환되는 문제 해결

## 👩‍💻 To Reviewers
- 간단한 로직 실수 였습니다.
  - 멤버가 떠난 후 남아있는 멤버의 수를 count하여 개인 폴더로 변환할지 여부를 검증하는 if문 로직이 추가되었습니다.
  - 폴더에 포함된 멤버 수를 count하는 메서드가 추가되었습니다.

## Related to
- Closes #161 
