### PR TITLE
feat: AWS ALB를 위한 Health Check API 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/presentation/controller/HealthCheckController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/HealthCheckController.java
@@ -1,0 +1,13 @@
+package com.flytrap.rssreader.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+    @GetMapping(value = "/api/health-check")
+    public ResponseEntity<String> healthCheck() {
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- EC2의 Spring Boot App에 SSL 설정을 하기 위해 ALB를 추하기로 하였습니다.
  - ALB가 정상 동작하기 위해 Health Check API가 필요하여 추가하게 되었습니다.
  - [ALB 상태 확인 DOCS](https://docs.aws.amazon.com/ko_kr/elasticloadbalancing/latest/application/target-group-health-checks.html)

## 👩‍💻 To Reviewers
- 

## Related to
- #175 
