### PR TITLE
폴더 삭제시 폴더에 구독하고 있던 블로그가 여전히 남아있는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/FolderSubscribeEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/FolderSubscribeEntityJpaRepository.java
@@ -15,6 +15,10 @@ public interface FolderSubscribeEntityJpaRepository extends
     void deleteBySubscribeIdAndFolderId(@Param("subscribeId") Long subscribeId,
             @Param("folderId") Long folderId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM FolderSubscribeEntity fs WHERE fs.folderId = :folderId")
+    void deleteAllByFolderId(@Param("folderId") Long folderId);
+
     List<FolderSubscribeEntity> findAllByFolderId(Long folderId);
 
     List<FolderSubscribeEntity> findAllByFolderIdIn(List<Long> folderIds);

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/PostListReadDslRepository.java
@@ -81,6 +81,7 @@ public class PostListReadDslRepository implements PostListReadRepository {
 
         BooleanBuilder builder = new BooleanBuilder();
         builder
+            .and(folderEntity.isDeleted.eq(false))
             .and(folderEntity.memberId.eq(memberId))
             .or(sharedFolderEntity.memberId.eq(memberId));
 

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -71,6 +71,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
 
         Folder verifiedFolder = folderVerifyOwnerService.getVerifiedFolder(folderId, member.id());
         Folder folder = folderService.deleteFolder(verifiedFolder, member.id());
+        folderSubscribeService.unsubscribeAllByFolder(folder);
 
         return new ApplicationResponse<>("폴더가 삭제되었습니다 : " + folder.getName());
     }

--- a/src/main/java/com/flytrap/rssreader/service/folder/FolderSubscribeService.java
+++ b/src/main/java/com/flytrap/rssreader/service/folder/FolderSubscribeService.java
@@ -27,6 +27,11 @@ public class FolderSubscribeService {
         folderSubscribeRepository.deleteBySubscribeIdAndFolderId(subscribeId, folderId);
     }
 
+    @Transactional
+    public void unsubscribeAllByFolder(Folder folder) {
+        folderSubscribeRepository.deleteAllByFolderId(folder.getId());
+    }
+
     @Transactional(readOnly = true)
     public List<Long> getFolderSubscribeId(Long folderId) {
         return folderSubscribeRepository.findAllByFolderId(folderId)


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더 삭제시 폴더에 구독하고 있던 블로그가 여전히 남아있는 문제 해결
  - 게시글 전체 목록 불러오기 Query에서 삭제된 폴더의 게시글은 제외하도록 조건을 추가하여 해결 
  - 폴더 삭제 시 폴더에 포함된 구복 블로그 목록도 같이 제거하도록 변경

## 👩‍💻 To Reviewers

## Related to
- closes #189 
