### PR TITLE
처음 블로그 구독하면 즉시 게시글을 수집하도록 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
+++ b/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
@@ -17,34 +17,30 @@ public class Subscribe implements DefaultDomain {
     private Long id;
     private String title;
     private String url;
-    private String description;
     private BlogPlatform platform;
     private boolean isNewSubscribe;
 
     @Builder
-    protected Subscribe(Long id, String title, String url, String description, BlogPlatform platform, boolean isNewSubscribe) {
+    protected Subscribe(Long id, String title, String url, BlogPlatform platform, boolean isNewSubscribe) {
         this.id = id;
         this.title = title;
         this.url = url;
-        this.description = description;
         this.platform = platform;
         this.isNewSubscribe = isNewSubscribe;
     }
 
-    public static Subscribe create(String url, String description) {
+    public static Subscribe create(String url) {
         return Subscribe.builder()
                 .url(url)
-                .description(description)
                 .isNewSubscribe(true)
                 .build();
     }
 
-    public static Subscribe of(Long id, String title, String url, String description, BlogPlatform platform, boolean isNewSubscribe) {
+    public static Subscribe of(Long id, String title, String url, BlogPlatform platform, boolean isNewSubscribe) {
         return Subscribe.builder()
                 .id(id)
                 .title(title)
                 .url(url)
-                .description(description)
                 .platform(platform)
                 .isNewSubscribe(isNewSubscribe)
                 .build();

--- a/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
+++ b/src/main/java/com/flytrap/rssreader/domain/subscribe/Subscribe.java
@@ -18,36 +18,35 @@ public class Subscribe implements DefaultDomain {
     private String title;
     private String url;
     private String description;
+    private BlogPlatform platform;
+    private boolean isNewSubscribe;
 
     @Builder
-    protected Subscribe(Long id, String title, String url, String description) {
+    protected Subscribe(Long id, String title, String url, String description, BlogPlatform platform, boolean isNewSubscribe) {
         this.id = id;
         this.title = title;
         this.url = url;
         this.description = description;
+        this.platform = platform;
+        this.isNewSubscribe = isNewSubscribe;
     }
 
     public static Subscribe create(String url, String description) {
         return Subscribe.builder()
                 .url(url)
                 .description(description)
+                .isNewSubscribe(true)
                 .build();
     }
 
-    public static Subscribe of(Long id, String title, String url, String description) {
+    public static Subscribe of(Long id, String title, String url, String description, BlogPlatform platform, boolean isNewSubscribe) {
         return Subscribe.builder()
                 .id(id)
                 .title(title)
                 .url(url)
                 .description(description)
-                .build();
-    }
-
-    public static Subscribe of(Long id, String title, String url) {
-        return Subscribe.builder()
-                .id(id)
-                .title(title)
-                .url(url)
+                .platform(platform)
+                .isNewSubscribe(isNewSubscribe)
                 .build();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/folder/FolderSubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/folder/FolderSubscribeEntity.java
@@ -43,7 +43,8 @@ public class FolderSubscribeEntity {
         return FolderSubscribeEntity.builder()
             .subscribeId(subscribe.getId())
             .folderId(folderId)
-            .description(subscribe.getDescription())
+            .description("") // FolderSubscribe에서 description은 회원이 수정할 수 있는 설명값.
+                             // 아직 해당 기능이 구현되지 않았으므로 빈 문자열을 전달해 준다.
             .build();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
@@ -70,7 +70,7 @@ public class SubscribeEntity {
      * @return 새로 추가된 구독 Subscribe Domain 객체
      */
     public Subscribe toNewSubscribeDomain() {
-        return Subscribe.of(this.id, this.title, this.url, "", this.platform, true);
+        return Subscribe.of(this.id, this.title, this.url, this.platform, true);
     }
 
     /**
@@ -82,7 +82,7 @@ public class SubscribeEntity {
      * @return 기존에 존재하던 구독 Subscribe Domain 객체
      */
     public Subscribe toExistingSubscribeDomain() {
-        return Subscribe.of(this.id, this.title, this.url, "", this.platform, false);
+        return Subscribe.of(this.id, this.title, this.url, this.platform, false);
     }
 
     public void updateTitle(String title) {

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
@@ -64,7 +64,7 @@ public class SubscribeEntity {
     /**
      * 이 SubscribeEntity를 새로 추가된 구독을 나타내는 Subscribe Domain 객체로 변환합니다.
      * 이 메서드는 구독이 새로 생성되었다는 것을 나타내는 플래그와 함께 Subscribe 도메인 객체를 초기화합니다.
-     * SubscribeEntity를가 데이터베이스에 아직 존재하지 않는 새 구독을 나타낼 때 이 메서드를 사용하세요.
+     * SubscribeEntity가 데이터베이스에 아직 존재하지 않는 새 구독을 나타낼 때 이 메서드를 사용하세요.
      * (기존에 존재하던 구독일 경우 toExistingSubscribeDomain()으로 변환하세요.)
      *
      * @return 새로 추가된 구독 Subscribe Domain 객체
@@ -76,7 +76,7 @@ public class SubscribeEntity {
     /**
      * 이 SubscribeEntity를 기존에 존재하던 구독을 나타내는 Subscribe Domain 객체로 변환합니다.
      * 이 메서드는 구독이 기존에 존재한다는 것을 나타내는 플래그와 함께 Subscribe 도메인 객체를 초기화합니다.
-     * SubscribeEntity를가 데이터베이스에 이미 존재하는 구독을 나타낼 때 이 메서드를 사용하세요.
+     * SubscribeEntity가 데이터베이스에 이미 존재하는 구독을 나타낼 때 이 메서드를 사용하세요.
      * (새로 추가된 구독일 경우 toNewSubscribeDomain()으로 변환하세요.)
      *
      * @return 기존에 존재하던 구독 Subscribe Domain 객체

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/subscribe/SubscribeEntity.java
@@ -52,16 +52,40 @@ public class SubscribeEntity {
                 .build();
     }
 
-    public Subscribe toDomain(RssFeedData rssFeedData) {
-        return Subscribe.of(this.id, rssFeedData.title(), url, rssFeedData.description());
+    public static SubscribeEntity from(Subscribe subscribe) {
+        return SubscribeEntity.builder()
+            .id(subscribe.getId())
+            .title(subscribe.getTitle())
+            .url(subscribe.getUrl())
+            .platform(subscribe.getPlatform())
+            .build();
     }
 
-    public Subscribe toDomain() {
-        return Subscribe.of(this.id, this.title, this.url);
+    /**
+     * 이 SubscribeEntity를 새로 추가된 구독을 나타내는 Subscribe Domain 객체로 변환합니다.
+     * 이 메서드는 구독이 새로 생성되었다는 것을 나타내는 플래그와 함께 Subscribe 도메인 객체를 초기화합니다.
+     * SubscribeEntity를가 데이터베이스에 아직 존재하지 않는 새 구독을 나타낼 때 이 메서드를 사용하세요.
+     * (기존에 존재하던 구독일 경우 toExistingSubscribeDomain()으로 변환하세요.)
+     *
+     * @return 새로 추가된 구독 Subscribe Domain 객체
+     */
+    public Subscribe toNewSubscribeDomain() {
+        return Subscribe.of(this.id, this.title, this.url, "", this.platform, true);
+    }
+
+    /**
+     * 이 SubscribeEntity를 기존에 존재하던 구독을 나타내는 Subscribe Domain 객체로 변환합니다.
+     * 이 메서드는 구독이 기존에 존재한다는 것을 나타내는 플래그와 함께 Subscribe 도메인 객체를 초기화합니다.
+     * SubscribeEntity를가 데이터베이스에 이미 존재하는 구독을 나타낼 때 이 메서드를 사용하세요.
+     * (새로 추가된 구독일 경우 toNewSubscribeDomain()으로 변환하세요.)
+     *
+     * @return 기존에 존재하던 구독 Subscribe Domain 객체
+     */
+    public Subscribe toExistingSubscribeDomain() {
+        return Subscribe.of(this.id, this.title, this.url, "", this.platform, false);
     }
 
     public void updateTitle(String title) {
         this.title = title;
     }
-
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -12,6 +12,7 @@ import com.flytrap.rssreader.presentation.dto.SessionMember;
 import com.flytrap.rssreader.presentation.dto.SubscribeRequest;
 import com.flytrap.rssreader.presentation.facade.OpenCheckFacade;
 import com.flytrap.rssreader.presentation.resolver.Login;
+import com.flytrap.rssreader.service.PostCollectService;
 import com.flytrap.rssreader.service.alert.AlertService;
 import com.flytrap.rssreader.service.folder.FolderSubscribeService;
 import com.flytrap.rssreader.service.folder.FolderUpdateService;
@@ -38,6 +39,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
     private final FolderVerifyOwnerService folderVerifyOwnerService;
     private final SubscribeService subscribeService;
     private final FolderSubscribeService folderSubscribeService;
+    private final PostCollectService postCollectService;
     private final AlertService alertService;
     private final OpenCheckFacade openCheckFacade;
 
@@ -89,6 +91,10 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
         Subscribe subscribe = subscribeService.subscribe(request);
         folderSubscribeService.folderSubscribe(subscribe,
             verifiedFolder.getId());
+
+        if (subscribe.isNewSubscribe()) {
+            postCollectService.processPostCollectionAsync(subscribe);
+        }
 
         FolderSubscribe folderSubscribe = FolderSubscribe.from(subscribe);
         folderSubscribe = openCheckFacade.addUnreadCountInFolderSubscribe(member.id(), subscribe, folderSubscribe);

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/FolderUpdateController.java
@@ -93,7 +93,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
             verifiedFolder.getId());
 
         if (subscribe.isNewSubscribe()) {
-            postCollectService.processPostCollectionAsync(subscribe);
+            postCollectService.collectPostsFromNewSubscribe(subscribe);
         }
 
         FolderSubscribe folderSubscribe = FolderSubscribe.from(subscribe);

--- a/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
@@ -96,12 +96,12 @@ public class PostCollectService {
     }
 
     /**
-     * 최초로 구독한 블로그 RSS에서 파싱된 게시글들을 DB에 Insert합니다.
+     * 최초로 구독한 블로그 RSS에서 파싱된 게시글들을 DB에 INSERT합니다.
      * 최초로 구독한 블로그이기에 기존에 저장된 블로그와 비교하여 게시글 변경 시 업데이트 하는 로직이 존재하지 않습니다.
      * 따라서 기존에 존재하는 블로그의 게시글 저장에는 사용하지 마세요.
      *
      * @param subscribeResource 최초로 구독한 블로그 RSS에서 파싱된 리소스.
-     * @param subscribe 최초로 구독한 블로그. PostEntity를 생성할 때 subscribeId를 주입 위해 사용됩니다.
+     * @param subscribe 최초로 구독한 블로그. PostEntity를 생성할 때 subscribeId를 주입하기 위해 사용됩니다.
      */
     private void saveAllPostsForNewSubscribe(RssSubscribeResource subscribeResource,
         SubscribeEntity subscribe) {

--- a/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
@@ -2,6 +2,7 @@ package com.flytrap.rssreader.service;
 
 import com.flytrap.rssreader.domain.post.q.PostBulkInsertPublisher;
 import com.flytrap.rssreader.domain.post.q.PostBulkInsertQueue;
+import com.flytrap.rssreader.domain.subscribe.Subscribe;
 import com.flytrap.rssreader.infrastructure.api.RssPostParser;
 import com.flytrap.rssreader.infrastructure.api.dto.RssSubscribeResource;
 import com.flytrap.rssreader.infrastructure.api.dto.RssSubscribeResource.RssItemResource;
@@ -35,7 +36,6 @@ public class PostCollectService {
      * @param subscribe 구독한 블로그
      * @return
      */
-
     public CompletableFuture<Map<String, String>> processPostCollectionAsync(
             SubscribeEntity subscribe) {
         return CompletableFuture.supplyAsync(
@@ -44,6 +44,11 @@ public class PostCollectService {
                             updateSubscribeTitle(resource, subscribe);
                             return savePosts(resource, subscribe);
                         }).orElse(new HashMap<>()));
+    }
+
+    public void processPostCollectionAsync(
+        Subscribe subscribe) {
+        processPostCollectionAsync(SubscribeEntity.from(subscribe));
     }
 
     private void updateSubscribeTitle(RssSubscribeResource subscribeResource,

--- a/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
@@ -10,6 +10,7 @@ import com.flytrap.rssreader.infrastructure.entity.post.PostEntity;
 import com.flytrap.rssreader.infrastructure.entity.subscribe.SubscribeEntity;
 import com.flytrap.rssreader.infrastructure.repository.PostEntityJpaRepository;
 import com.flytrap.rssreader.infrastructure.repository.SubscribeEntityJpaRepository;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,13 +43,24 @@ public class PostCollectService {
                 () -> postParser.parseRssDocuments(subscribe.getUrl())
                         .map(resource -> {
                             updateSubscribeTitle(resource, subscribe);
-                            return savePosts(resource, subscribe);
+                            return savePostsForBulkInsert(resource, subscribe);
                         }).orElse(new HashMap<>()));
     }
 
-    public void processPostCollectionAsync(
-        Subscribe subscribe) {
-        processPostCollectionAsync(SubscribeEntity.from(subscribe));
+    /**
+     * 최초로 구독한 블로그의 RSS에서 게시글들을 파싱한 후 수집(DB에 저장)합니다.
+     * 최초로 구독한 블로그이기에 기존에 저장된 블로그와 비교하여 게시글 변경 시 업데이트 하는 로직이 존재하지 않습니다.
+     * 따라서 기존에 존재하는 블로그의 게시글 수집에는 사용하지 마세요.
+     *
+     * @param subscribe 구독한 블로그
+     */
+    public void collectPostsFromNewSubscribe(Subscribe subscribe) {
+
+        postParser.parseRssDocuments(subscribe.getUrl()).ifPresent(
+            resource -> {
+                saveAllPostsForNewSubscribe(resource, SubscribeEntity.from(subscribe));
+            }
+        );
     }
 
     private void updateSubscribeTitle(RssSubscribeResource subscribeResource,
@@ -58,7 +70,7 @@ public class PostCollectService {
     }
 
     //TODO: 글이 새로 추가되면 슬랙에 보낼URL을 기억한다.
-    private Map<String, String> savePosts(RssSubscribeResource subscribeResource,
+    private Map<String, String> savePostsForBulkInsert(RssSubscribeResource subscribeResource,
             SubscribeEntity subscribe) {
         List<PostEntity> posts = postEntityJpaRepository.findAllBySubscribeOrderByPubDateDesc(
                 subscribe);
@@ -81,6 +93,26 @@ public class PostCollectService {
             //     postEntityJpaRepository.save(post);
         }
         return postUrlMap;
+    }
+
+    /**
+     * 최초로 구독한 블로그 RSS에서 파싱된 게시글들을 DB에 Insert합니다.
+     * 최초로 구독한 블로그이기에 기존에 저장된 블로그와 비교하여 게시글 변경 시 업데이트 하는 로직이 존재하지 않습니다.
+     * 따라서 기존에 존재하는 블로그의 게시글 저장에는 사용하지 마세요.
+     *
+     * @param subscribeResource 최초로 구독한 블로그 RSS에서 파싱된 리소스.
+     * @param subscribe 최초로 구독한 블로그. PostEntity를 생성할 때 subscribeId를 주입 위해 사용됩니다.
+     */
+    private void saveAllPostsForNewSubscribe(RssSubscribeResource subscribeResource,
+        SubscribeEntity subscribe) {
+
+        List<PostEntity> postsToSave = new ArrayList<>();
+
+        for (RssItemResource itemResource : subscribeResource.itemResources()) {
+            postsToSave.add(PostEntity.from(itemResource, subscribe));
+        }
+
+        postEntityJpaRepository.saveAll(postsToSave);
     }
 
     private static Map<String, PostEntity> convertListToHashSet

--- a/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
+++ b/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
@@ -19,13 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SubscribeService {
 
-    //TODO:
-    // step1검색을 누르면 유효한 RSS인지 검증한다
-    // step2 이미 구독한 블로그라면 즉 DB에 저장되어있다면
-    // 새로 구독하지말고 DB에있는 url(정보를) 가져다써라
-    //  step3하지만 새로운 블로그라면 새로 추가해주자
-    //  새로운 구독이라면 DB 관계형테이블 구독 에 넣어라
-
     private final SubscribeEntityJpaRepository subscribeRepository;
     private final RssChecker rssChecker;
 
@@ -34,11 +27,10 @@ public class SubscribeService {
         RssFeedData rssFeedData = rssChecker.parseRssDocuments(request).orElseThrow();
 
         if (!subscribeRepository.existsByUrl(request.blogUrl())) {
-            //TODO: 없으면 새로 저장한다.
             return subscribeRepository.save(SubscribeEntity.from(rssFeedData))
                 .toNewSubscribeDomain();
         }
-        //TODO: 도메인을 DB에 넣을거면 꺼내 써는 방향?, 일단은 도메인을 만들어 리턴한다.
+
         return subscribeRepository.findByUrl(request.blogUrl()).orElseThrow()
             .toExistingSubscribeDomain();
     }

--- a/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
+++ b/src/main/java/com/flytrap/rssreader/service/SubscribeService.java
@@ -36,10 +36,11 @@ public class SubscribeService {
         if (!subscribeRepository.existsByUrl(request.blogUrl())) {
             //TODO: 없으면 새로 저장한다.
             return subscribeRepository.save(SubscribeEntity.from(rssFeedData))
-                    .toDomain(rssFeedData);
+                .toNewSubscribeDomain();
         }
         //TODO: 도메인을 DB에 넣을거면 꺼내 써는 방향?, 일단은 도메인을 만들어 리턴한다.
-        return subscribeRepository.findByUrl(request.blogUrl()).orElseThrow().toDomain(rssFeedData);
+        return subscribeRepository.findByUrl(request.blogUrl()).orElseThrow()
+            .toExistingSubscribeDomain();
     }
 
     @Transactional
@@ -53,7 +54,7 @@ public class SubscribeService {
 
     public List<Subscribe> read(Collection<Long> subscribeIds) {
         return subscribeRepository.findAllById(subscribeIds).stream()
-                .map(SubscribeEntity::toDomain)
+                .map(SubscribeEntity::toExistingSubscribeDomain)
                 .toList();
     }
 

--- a/src/test/java/com/flytrap/rssreader/fixture/SubscribeFixtureFactory.java
+++ b/src/test/java/com/flytrap/rssreader/fixture/SubscribeFixtureFactory.java
@@ -10,7 +10,6 @@ public class SubscribeFixtureFactory {
                 .id(1L)
                 .title("에이프의 블로그")
                 .url("https://blog.naver.com/PostList.nhn?blogId=ape")
-                .description("에이프의 블로그")
                 .build();
     }
 
@@ -19,7 +18,6 @@ public class SubscribeFixtureFactory {
                 .id(id)
                 .title("??의 블로그")
                 .url("https://blog.naver.com/PostList.nhn?blogId=??")
-                .description("누군가의 블로그")
                 .build();
     }
 }

--- a/src/test/java/com/flytrap/rssreader/service/SubscribeServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/SubscribeServiceTest.java
@@ -89,9 +89,8 @@ public class SubscribeServiceTest {
     @DisplayName("URL폴더 구독을 취소한다.")
     void unsubscribe() {
         // given
-        Optional<RssFeedData> rssFeedData = FixtureFactory.generateRssData();
         SubscribeEntity subscribeEntity = generateSubscribeEntity();
-        Subscribe subscribe = subscribeEntity.toDomain(rssFeedData.orElseThrow());
+        Subscribe subscribe = subscribeEntity.toExistingSubscribeDomain();
         when(subscribeRepository.findById(subscribe.getId())).thenReturn(
                 Optional.of(subscribeEntity));
 


### PR DESCRIPTION
## 🔑 Key Changes
- 처음 블로그 구독하면 즉시 게시글을 수집하도록 변경

## 👩‍💻 To Reviewers
- 게시글 수집 로직이 복잡해지다 보니 메서드에 JavaDoc 주석을 추가했어요. 주석의 설명이 부족하거나 이해가 안가시면 알려주세요. 감사합니다. 

## ✳️ 기존 코드에서 변경된 부분
### 🔹 SubscribeDomain이 새로 추가된 구독인지 알수 있도록 변경
- 블로그 구독 시 처음 구독하는(Subscribe Table에 존재하지 않는) 블로그 일때만 게시글수집을 즉시 수행하도록 하였습니다.
- 위 로직을 구현하기 위해 Subscribe Domain에 해당 구독이 처음 생성되었는지 아닌지를 나타내는 필드가 추가되었습니다.

## ✳️ 새로 추가된 부분
### 🔹 게시글 즉시 수집 메서드
- 처름 구독하는 블로그의 경우 기존의 queue에 저장하지 않고 바로 DB에 저장하는 메서드가 추가되었습니다.

## Related to
- closes #191 
