### PR TITLE
게시글 중복 저장되는 버그 해결 -  2

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/collect/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/collect/PostCollectService.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -62,11 +61,7 @@ public class PostCollectService {
     }
 
     private List<PostEntity> generateCollectedPostsForUpsert(RssPostsData postData, SubscribeEntity subscribe) {
-        var pageable = PageRequest.of(
-            0, (int) Math.ceil(postData.getItemSize() * 1.5),
-            Sort.by(Direction.DESC, "pubDate"));
-        List<PostEntity> existingPosts = postRepository.findAllBySubscribe(
-            subscribe, pageable);
+        List<PostEntity> existingPosts = postRepository.findAllBySubscribe(subscribe);
 
         Map<String, PostEntity> existingPostsMap = convertListToHashSet(existingPosts);
         List<PostEntity> collectedPosts = new ArrayList<>();

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/collect/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/collect/PostCollectService.java
@@ -63,7 +63,7 @@ public class PostCollectService {
 
     private List<PostEntity> generateCollectedPostsForUpsert(RssPostsData postData, SubscribeEntity subscribe) {
         var pageable = PageRequest.of(
-            0, postData.getItemSize(),
+            0, (int) Math.ceil(postData.getItemSize() * 1.5),
             Sort.by(Direction.DESC, "pubDate"));
         List<PostEntity> existingPosts = postRepository.findAllBySubscribe(
             subscribe, pageable);

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostEntityJpaRepository.java
@@ -3,16 +3,14 @@ package com.flytrap.rssreader.api.post.infrastructure.repository;
 import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
 import com.flytrap.rssreader.api.post.infrastructure.output.PostSubscribeCountOutput;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.SubscribeEntity;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface PostEntityJpaRepository extends JpaRepository<PostEntity, Long> {
 
-    List<PostEntity> findAllBySubscribe(SubscribeEntity subscribe, Pageable pageable);
+    List<PostEntity> findAllBySubscribe(SubscribeEntity subscribe);
 
     @Query("select p.subscribe.id as subscribeId, count(p.id) as postCount "
             + "from PostEntity p "

--- a/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
+++ b/src/main/java/com/flytrap/rssreader/global/utill/DateConvertor.java
@@ -7,18 +7,36 @@ import java.util.Locale;
 
 public class DateConvertor {
 
-    private static final String DATE_FORMAT_ABBREVIATION = "EEE, dd MMM yyyy HH:mm:ss z";
-    private static final String DATE_FORMAT_NUMERICAL = "EEE, dd MMM yyyy HH:mm:ss Z";
+    /*
+     * 아래 변수들은 다양한 블로그 플랫폼에서 사용되는 여러 날짜 형식을 처리하기 위한 것입니다.
+     * 아래 규칙들은 국제 표준인 ISO 8601을 따르는 날짜 및 시간 형식 패턴 문자열입니다.
+     * 국제 표준이라 변할 경우가 없고, 코드 수정시 매번 찾아보기 번거러우므로 주석을 달아놓습니다.
+     *
+     * - "EEE"는 요일을 세 글자 약어로 표현합니다 (예: "Wed").
+     * - "d"는 일자를 표현하며, 한 자리 일자는 0 없이 표현합니다 (예: "1"). 변수명은 SINGLE_DIGIT_DAY로 씁니다
+     * - "dd"는 일자를 표현하며, 1-9일에는 앞에 0을 붙여 표현합니다 (예: "01"). 변수명은 DOUBLE_DIGIT_DAY로 씁니다
+     * - "MMM"은 세 글자 약어로 된 월을 나타냅니다 (예: "Nov").
+     * - "yyyy"는 네 자리 연도입니다.
+     * - "HH:mm:ss"는 24시간 기준 시, 분, 초를 나타냅니다.
+     * - "z"는 축약된 시간대 이름을 지정합니다 (예: "PST", "GMT") 변수명은 ABBREVIATED_TIMEZONE로 씁니다
+     * - "Z"는 UTC로부터의 수치적 시간대 오프셋을 나타냅니다 (예: "+0900"). 변수명은 NUMERICAL_TIMEZONE로 씁니다.
+     */
+    private static final String SINGLE_DIGIT_DAY_ABBREVIATED_TIMEZONE = "EEE, d MMM yyyy HH:mm:ss z";
+    private static final String DOUBLE_DIGIT_DAY_ABBREVIATED_TIMEZONE = "EEE, dd MMM yyyy HH:mm:ss z";
+    private static final String SINGLE_DIGIT_DAY_NUMERICAL_TIMEZONE = "EEE, d MMM yyyy HH:mm:ss Z";
+    private static final String DOUBLE_DIGIT_DAY_NUMERICAL_TIMEZONE = "EEE, dd MMM yyyy HH:mm:ss Z";
 
     private static final DateTimeFormatter[] FORMATTERS = {
-        DateTimeFormatter.ofPattern(DATE_FORMAT_ABBREVIATION).withLocale(Locale.ENGLISH),
-        DateTimeFormatter.ofPattern(DATE_FORMAT_NUMERICAL).withLocale(Locale.ENGLISH),
+        DateTimeFormatter.ofPattern(SINGLE_DIGIT_DAY_ABBREVIATED_TIMEZONE, Locale.ENGLISH),
+        DateTimeFormatter.ofPattern(DOUBLE_DIGIT_DAY_ABBREVIATED_TIMEZONE, Locale.ENGLISH),
+        DateTimeFormatter.ofPattern(SINGLE_DIGIT_DAY_NUMERICAL_TIMEZONE, Locale.ENGLISH),
+        DateTimeFormatter.ofPattern(DOUBLE_DIGIT_DAY_NUMERICAL_TIMEZONE, Locale.ENGLISH),
         DateTimeFormatter.ISO_DATE_TIME,
     };
 
     /**
      * "Wed, 29 Nov 2023 13:49:14 +0900" 및 "Tue, 07 Nov 2023 14:12:30 GMT"
-     * 형식 등의 문자열을 Instant 객체로 변환하는 메서드
+     * 여러 형식의 날짜 문자열을 Instant 객체로 변환하는 메서드
      *
      * @param parsingDate Instant 객체로 변경할 날짜 문자열
      * @return Instant 객체


### PR DESCRIPTION
## 🔑 Key Changes
- 게시글 중복 오류 해결 

## 👩‍💻 To Reviewers
### [문제]
- 게시글이 중복 저장되고 있음. 이번에는 무작위로 중복된는 게 아니라 특정 블로그의 특정 게시글만 중복되는 상황

### [기존 로직]
- RSS 문서에서 게시글을 파싱한다. 파싱된 게시글 수만큼 DB에서 게시글을 불러와 비교한 후 신규 게시글은 INSERT, 기존 게시글은 UPDATE 하고 있다

### [문제 원인]
- 블로그의 게시글이 수정 되었을 경우 파싱한 게시글과 DB에서 불러온 게시글간 불일치가 발생하여 올바른 비교를 수행할 수 없어서 발생한 문제

![collect post 게시글 중복 문제 2탄](https://github.com/FlytrapHub/RSS-Reader/assets/86359180/89584ebd-a4d1-4d9d-a382-ff0ee1799e73)

### [해결 방법]
- 일단 Post 비교시 Subscribe당 모든 Post를 SELECT 해와서 비교하도록 했습니다. DB에서 모든 Post를 다 불러오기 때문에 파싱해온 Post와 불일치할 일이 없습니다.

### [추가 건의사항]
- DB에 접근하는 로직을 줄이려면 Post Entity의 ID를 `guid`와 `pub_date`의 조합으로 만드는게 좋을 것 같습니다. 이를 해싱한 데이터를 ID로 두면 DB에서 Post를 불러오지 않아도 어플리케이션 단에서 ID를 만드는 것만으로도 중복 문제를 해결할 수 있을 것 같아요. 파싱한 데이터로 Post Entity를 만들어 save 해주기만 하면 중복 저장을 거를 수 있을 것 같습니다. 트랜잭션도 없고 따로 따로 INSERT or UPDATE하기 때문에 한 작업의 실패로 모든 작업이 실패할 일은 없을 것 같습니다.


## Related to
- #214 
