### PR TITLE
리팩토링 후 깨진 게시글 열기 기능 복구

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostReadService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostReadService.java
@@ -1,22 +1,20 @@
 package com.flytrap.rssreader.api.post.business.service;
 
 
+import com.flytrap.rssreader.api.auth.presentation.dto.SessionMember;
 import com.flytrap.rssreader.api.post.business.event.postOpen.PostOpenEvent;
 import com.flytrap.rssreader.api.post.domain.Post;
 import com.flytrap.rssreader.api.post.infrastructure.output.PostSubscribeCountOutput;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostEntityJpaRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostListReadRepository;
-import com.flytrap.rssreader.api.post.infrastructure.repository.PostOpenRepository;
 import com.flytrap.rssreader.global.event.PublishEvent;
 import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
-import com.flytrap.rssreader.api.auth.presentation.dto.SessionMember;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +22,6 @@ public class PostReadService {
 
     private final PostEntityJpaRepository postEntityJpaRepository;
     private final PostListReadRepository postListReadRepository;
-    private final PostOpenRepository postOpenRepository;
 
     @Transactional(readOnly = true)
     @PublishEvent(eventType = PostOpenEvent.class,

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostReadService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostReadService.java
@@ -28,7 +28,7 @@ public class PostReadService {
 
     @Transactional(readOnly = true)
     @PublishEvent(eventType = PostOpenEvent.class,
-            params = "#{T(com.flytrap.rssreader.service.dto.PostOpenParam).create(#sessionMember.id(), #postId)}")
+            params = "#{T(com.flytrap.rssreader.api.post.business.event.postOpen.PostOpenEventParam).create(#sessionMember.id(), #postId)}")
     public Post getPost(SessionMember sessionMember, Long postId) {
 
         return postListReadRepository.findById(postId)


### PR DESCRIPTION
## 🔑 Key Changes
- 리팩토링 후 깨진 게시글 열기 기능 복구

## 👩‍💻 To Reviewers
- 이벤트 발행시 `@ PublishEvent `에 설정한 이벤트 객체의 경로가 변경되어 생긴 버그였습니다. 이벤트 객체의 경로를 변경하여 문제가 해결되었습니다.

## Related to
- #214 
