### PR TITLE
무중단 배포

### DIFF
--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 
 on:
   push:
-    branches: [ "release-test" ]
+    branches: [ "release" ]
 
 env:
   working-directory: .
@@ -77,7 +77,7 @@ jobs:
             username: ubuntu
             key: ${{ secrets.AWS_KEY }}
             source: "./deploy.sh"
-            target: "/home/ubuntu/"
+            target: "/home/ubuntu/RSS-Reader"
 
       - name: 원격 SSH 명령 실행
         uses: appleboy/ssh-action@master
@@ -89,6 +89,8 @@ jobs:
             cd RSS-Reader/
             chmod +x ./run.sh
             ./run.sh
+            chmod +x ./deploy.sh
+            ./deploy.sh
 
       - name: 보안 그룹에서 Github Actions IP 제거
         run: |

--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -2,11 +2,11 @@ name: Build and Deploy
 
 on:
   push:
-    branches: ["release"]
+    branches: [ "release-test" ]
 
 env:
   working-directory: .
-  AWS_REGION: ap-northeast-2                   
+  AWS_REGION: ap-northeast-2
   AWS_SG_NAME: FlytrapDevelopment
   AWS_SG_ID: sg-0895e77b2da12a6c9
 
@@ -15,72 +15,81 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Get Public IP
-      id: publicip
-      run: |
-        response=$(curl -s canhazip.com)
-        echo "ip=$response" >> "$GITHUB_OUTPUT"
+      - name: Get Public IP
+        id: publicip
+        run: |
+          response=$(curl -s canhazip.com)
+          echo "ip=$response" >> "$GITHUB_OUTPUT"
 
-    - name: Checkout Repository and Submodules
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.G_TOKEN }}
-        submodules: true
+      - name: Checkout Repository and Submodules
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.G_TOKEN }}
+          submodules: true
 
-    - name: JDK 17 설정
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        server-id: github 
-        settings-path: ${{ github.workspace }} 
+      - name: JDK 17 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
 
-    - name: Gradle로 빌드
-      run: |
-        git submodule update --init --recursive
-        chmod +x gradlew
-        ./gradlew clean build
-        
-    - name: AWS 자격 증명 설정
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }} 
-         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
-         aws-region: ${{env.AWS_REGION}}
+      - name: Gradle로 빌드
+        run: |
+          git submodule update --init --recursive
+          chmod +x gradlew
+          ./gradlew clean build
 
-    - name: 보안 그룹에 Github Actions IP 추가
-      run: |
-        aws ec2 authorize-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.publicip.outputs.ip }}/32
+      - name: AWS 자격 증명 설정
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{env.AWS_REGION}}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Build and push
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        tags: ghcr.io/flytraphub/rss-reader:release
+      - name: 보안 그룹에 Github Actions IP 추가
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.publicip.outputs.ip }}/32
 
-    - name: 원격 SSH 명령 실행
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.AWS_HOST }}
-        username: ubuntu
-        key: ${{ secrets.AWS_KEY }}
-        script: |
-          cd RSS-Reader/
-          chmod +x ./run.sh
-          ./run.sh
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: 보안 그룹에서 Github Actions IP 제거
-      run: |
-         aws ec2 revoke-security-group-ingress  --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.publicip.outputs.ip }}/32
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/flytraphub/rss-reader:release
+
+      - name: deploy.sh 복사
+        uses: appleboy/scp-action@master
+        with:
+            host: ${{ secrets.AWS_HOST }}
+            username: ubuntu
+            key: ${{ secrets.AWS_KEY }}
+            source: "./deploy.sh"
+            target: "/home/ubuntu/"
+
+      - name: 원격 SSH 명령 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_HOST }}
+          username: ubuntu
+          key: ${{ secrets.AWS_KEY }}
+          script: |
+            cd RSS-Reader/
+            chmod +x ./run.sh
+            ./run.sh
+
+      - name: 보안 그룹에서 Github Actions IP 제거
+        run: |
+          aws ec2 revoke-security-group-ingress  --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.publicip.outputs.ip }}/32

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+IS_GREEN=$(docker ps | grep green) # 현재 실행중인 App이 green인지 확인
+
+DEFAULT_CONF="./nginx/conf.d/nginx.conf"
+
+docker-compose up -d balancer
+docker-compose up -d redis
+
+if [ -z $IS_GREEN  ];then # blue라면
+	echo "### BLUE => GREEN ###"
+	echo "1. get green image"
+	docker-compose pull green # 이미지 받아서
+	echo "1-1. blue container down"
+  docker-compose stop blue
+	echo "2. green container up"
+	docker-compose up -d green # 컨테이너 실행
+	while [ 1 = 1 ]; do
+		echo "3. green health check..."
+		sleep 3
+		REQUEST=$(docker exec balancer curl http://green:8080) # green으로 request
+		if [ -n "$REQUEST" ]; then # 서비스 가능하면 break
+			echo "health check success"
+			break ;
+		fi
+	done;
+	sed -i 's/blue/green/g' $DEFAULT_CONF # nginx가 green을 가리키도록 변경
+	echo "4. reload nginx"
+	docker exec balancer nginx -s reload
+else
+	echo "### GREEN => BLUE ###"
+	echo "1. get blue image"
+	docker-compose pull blue
+	echo "1-1. green container down"
+  docker-compose stop green
+	echo "2. blue container up"
+	docker-compose up -d blue
+	while [ 1 = 1 ]; do
+		sleep 3
+		echo "3. blue health check..."
+		REQUEST=$(docker exec balancer curl http://blue:8080)
+		if [ -n "$REQUEST" ]; then
+				echo "health check success"
+				break ;
+		fi
+    done;
+	sed -i 's/green/blue/g' $DEFAULT_CONF
+	echo "4. reload nginx"
+	docker exec balancer nginx -s reload
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+#docker-compose.yml
 version: "3"
 
 services:
@@ -12,10 +13,7 @@ services:
       - ./nginx/conf.d:/etc/nginx/conf.d
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
-    depends_on:
-      - was-dev
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
-
 
   certbot:
     image: certbot/certbot
@@ -25,11 +23,17 @@ services:
       - ./data/certbot/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
-  was-dev:
+  blue:
     image: ghcr.io/flytraphub/rss-reader:release
     ports:
       - "8080:8080"
-    container_name: was-dev
+    container_name: blue
+
+  green:
+    image: ghcr.io/flytraphub/rss-reader:release
+    ports:
+      - "8080:8080"
+    container_name: green
 
   redis:
     image: redis:latest

--- a/nginx/conf.d/nginx.conf
+++ b/nginx/conf.d/nginx.conf
@@ -1,5 +1,5 @@
 upstream back-server {
-    server was-dev:8080;
+  server blue:8080;
 }
 
 server {

--- a/nginx/conf.d/nginx.conf
+++ b/nginx/conf.d/nginx.conf
@@ -1,5 +1,5 @@
 upstream back-server {
-  server blue:8080;
+  server green:8080;
 }
 
 server {

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,9 @@ echo "👉 Starting Docker Compose..."
 cd RSS-Reader/
 sudo docker-compose up -d
 
+echo "👉 blue-green deploy.sh run..."
+chmod 777 ./deploy.sh./deploy.sh
+
 echo "👉 Cleaning up unused Docker images..."
 sudo docker image prune -a -f
 


### PR DESCRIPTION
## ☑️ 진행할 작업
RSS-Reader는 현재 유지 보수하면서 기능을 확장해 나가고 있는 와중 자동화된, 주기적인 배포의 필요성이 커졌습니다.
아직 까지는 배포 시 기존 서버를 내리고, 새롭게 서버를 올리는 과정에서 필연적인 down time이 발생할 수 밖에 없습니다.
CI, CD를 통한 자동 배포, 통합 구조는 만들어졌지만 무중단 배포는 아직 이뤄지지 않고 있습니다. 서버를 죽지 않게 하는 것 즉 배포로 인해 down time이 발생하지 않게 사용자에게 좋은 경험을 주는 서비스를 만들기 위해 시도했습니다.
## 무중단 배포

![image](https://github.com/FlytrapHub/RSS-Reader/assets/53938366/fbd61807-c2f9-4ce5-a5cf-0accf7d44ffc)
저희 EC2 사진 입니다. blue 컨테이너가 실행 중일 때 만약 새롭게 realse브런치를 통해 배포된다면.

![image](https://github.com/FlytrapHub/RSS-Reader/assets/53938366/f4fb6fa7-3853-4789-a34b-f86742c88b97)
새로운 컨테이너 (green) 을 띄우고 헬스체킹을 한 후 기존 컨테이너는 down 시킵니다.

![image](https://github.com/FlytrapHub/RSS-Reader/assets/53938366/aa67c91f-5e3b-430b-b16e-4ac68a6f7ff7)
그 후 Nginx conf설정은 cpt 명령어를 통해 새로운 컨테이너 (현재 blue에서 green으로 변경 됐다고 가정)의 설정으로 변경합니다.

![image](https://github.com/FlytrapHub/RSS-Reader/assets/53938366/81d4273c-1090-41c7-88c1-3de7cd1dc973)
최종적인 모습입니다.

## 추가적으로
추가적으로 클라이언트 요청을 처리하는 도중에 프로세스가 죽어버리는 경우 (blue컨테이너가 떠있는 도중 요청을 처리하는 와중에 배포로 인해 green 컨테이너로 교체되는 경우) 이런 문제를 Graceful Shutdown 문제라 하는데 이 또한 지금은 사용자가 많지 않아 크게 고려할 요소는 아니더라도 추후 개선해야 할 것 같습니다.
 
 또한 로드밸런서 기능을 Nginx를 통해 해보고 싶었는데 was를 두 개 운영하는건 ec2에 부담이 상당히 많이 가는 것 같아 보류했습니다.

## Related to
-  #228 
