### PR TITLE
구독별 게시글 불러오기 API 버그 수정 - 다른 구독의 게시글을 불러오는 문제

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListReadService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListReadService.java
@@ -7,7 +7,9 @@ import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderVal
 import com.flytrap.rssreader.api.post.domain.Post;
 import com.flytrap.rssreader.api.post.domain.PostFilter;
 import com.flytrap.rssreader.api.post.infrastructure.implementation.PostQuery;
-import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
+import com.flytrap.rssreader.api.subscribe.domain.Subscription;
+import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
+import com.flytrap.rssreader.api.subscribe.infrastructure.implement.SubscriptionQuery;
 import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostListReadService {
 
     private final FolderValidator folderValidator;
+    private final SubscriptionQuery subscriptionQuery;
     private final PostQuery postQuery;
 
     public List<Post> getPostsByAccount(AccountId accountId, PostFilter postFilter,
@@ -38,10 +41,11 @@ public class PostListReadService {
         return postQuery.readAllByFolder(accountId, folderId, postFilter, pageable);
     }
 
-    public List<Post> getPostsBySubscription(AccountId accountId, RssSourceId rssSourceId,
+    public List<Post> getPostsBySubscription(AccountId accountId, SubscriptionId subscriptionId,
         PostFilter postFilter, Pageable pageable) {
+        Subscription subscription = subscriptionQuery.read(subscriptionId);
 
-        return postQuery.readAllBySubscription(accountId, rssSourceId, postFilter, pageable);
+        return postQuery.readAllBySubscription(accountId, subscription.getRssSourceId(), postFilter, pageable);
     }
 
     public List<Post> getBookmarkedPosts(AccountId accountId, PostFilter postFilter,

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListReadController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListReadController.java
@@ -7,7 +7,7 @@ import com.flytrap.rssreader.api.post.business.service.PostListReadService;
 import com.flytrap.rssreader.api.post.domain.PostFilter;
 import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostListReadControllerApi;
 import com.flytrap.rssreader.api.post.presentation.dto.response.PostResponse;
-import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
+import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.global.presentation.resolver.Login;
 import java.util.List;
@@ -68,7 +68,7 @@ public class PostListReadController implements PostListReadControllerApi {
         @Login AccountCredentials accountCredentials) {
 
         List<PostResponse> posts = postListReadService.getPostsBySubscription(
-                new AccountId(accountCredentials.id().value()), new RssSourceId(subscriptionId),
+                new AccountId(accountCredentials.id().value()), new SubscriptionId(subscriptionId),
                 postFilter, pageable)
             .stream()
             .map(PostResponse::from)

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/Subscription.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/Subscription.java
@@ -15,12 +15,15 @@ public class Subscription implements DefaultDomain {
     private final String title;
     private final String url;
     private final BlogPlatform platform;
+    private final RssSourceId rssSourceId;
 
     @Builder
-    protected Subscription(SubscriptionId id, String title, String url, BlogPlatform platform) {
+    protected Subscription(SubscriptionId id, String title, String url, BlogPlatform platform,
+        RssSourceId rssSourceId) {
         this.id = id;
         this.title = title;
         this.url = url;
         this.platform = platform;
+        this.rssSourceId = rssSourceId;
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/entity/SubscriptionEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/entity/SubscriptionEntity.java
@@ -1,5 +1,6 @@
 package com.flytrap.rssreader.api.subscribe.infrastructure.entity;
 
+import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
 import com.flytrap.rssreader.api.subscribe.domain.Subscription;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.global.exception.domain.InconsistentDomainException;
@@ -48,6 +49,7 @@ public class SubscriptionEntity {
             .url(rssSourceEntity.getUrl())
             .title(rssSourceEntity.getTitle())
             .platform(rssSourceEntity.getPlatform())
+            .rssSourceId(new RssSourceId(rssSourceEntity.getId()))
             .build();
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionQuery.java
@@ -2,8 +2,10 @@ package com.flytrap.rssreader.api.subscribe.infrastructure.implement;
 
 import com.flytrap.rssreader.api.folder.domain.FolderId;
 import com.flytrap.rssreader.api.subscribe.domain.Subscription;
+import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.output.SubscriptionOutput;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.SubscriptionDslRepository;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,13 @@ import org.springframework.stereotype.Component;
 public class SubscriptionQuery {
 
     private final SubscriptionDslRepository subscriptionDslRepository;
+
+    public Subscription read(SubscriptionId subscriptionId) {
+        return subscriptionDslRepository
+            .findById(subscriptionId.value())
+            .orElseThrow(() -> new NoSuchDomainException(Subscription.class))
+            .toReadOnly();
+    }
 
     public List<Subscription> readAllByFolder(FolderId folderId) {
         return subscriptionDslRepository

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/output/SubscriptionOutput.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/output/SubscriptionOutput.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.api.subscribe.infrastructure.output;
 
 import com.flytrap.rssreader.api.subscribe.domain.BlogPlatform;
+import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
 import com.flytrap.rssreader.api.subscribe.domain.Subscription;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 
@@ -8,7 +9,8 @@ public record SubscriptionOutput(
     long id,
     String title,
     String url,
-    BlogPlatform platform
+    BlogPlatform platform,
+    long rssSourceId
 ) {
     public Subscription toReadOnly() {
         return Subscription.builder()
@@ -16,6 +18,7 @@ public record SubscriptionOutput(
             .title(title)
             .url(url)
             .platform(platform)
+            .rssSourceId(new RssSourceId(rssSourceId))
             .build();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/repository/SubscriptionDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/repository/SubscriptionDslRepository.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,6 +33,25 @@ public class SubscriptionDslRepository {
         return fetchOne != null;
     }
 
+    public Optional<SubscriptionOutput> findById(long subscriptionId) {
+        return Optional.of(
+            queryFactory
+                .selectDistinct(
+                    Projections.constructor(SubscriptionOutput.class,
+                        subscriptionEntity.id,
+                        rssSourceEntity.title,
+                        rssSourceEntity.url,
+                        rssSourceEntity.platform,
+                        rssSourceEntity.id
+                    )
+                ).from(subscriptionEntity)
+                .join(rssSourceEntity)
+                .on(subscriptionEntity.rssSourceId.eq(rssSourceEntity.id))
+                .where(subscriptionEntity.id.eq(subscriptionId))
+                .fetchFirst()
+        );
+    }
+
     public List<SubscriptionOutput> findAllByFolder(long folderId) {
         return queryFactory
             .selectDistinct(
@@ -39,7 +59,8 @@ public class SubscriptionDslRepository {
                     subscriptionEntity.id,
                     rssSourceEntity.title,
                     rssSourceEntity.url,
-                    rssSourceEntity.platform
+                    rssSourceEntity.platform,
+                    rssSourceEntity.id
                 )
             ).from(subscriptionEntity)
             .join(rssSourceEntity)


### PR DESCRIPTION
## 🔑 Key Changes
- 구독별 게시글 불러오기 API 버그 수정

## 👩‍💻 To Reviewers
### 문제
- 구독별 게시글 불러오기 시 다른 구독의 게시글을 불러오는 문제

### 문제 원인
- 구독별 게시글 불러오는 SQL에 입력해야할 파라미터에 잘못된 값이 들어가 생긴 버그 
  - where절에 RssSourceId로 조건을 걸었으나 파라마터로 SubscriptionId가 들어가 잘못된 결과를 반환하였음

- SQL문을 수정하여 해결

## Related to
- #243 
