### PR TITLE
API URL중 rss를 subscriptions로 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionController.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionController.java
@@ -27,7 +27,7 @@ public class SubscriptionController implements SubscriptionControllerApi {
     private final SubscriptionService subscriptionService;
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/api/folders/{folderId}/rss")
+    @PostMapping("/api/folders/{folderId}/subscriptions")
     public ApplicationResponse<SubscriptionResponse> addSubscribeToFolder(
         @PathVariable Long folderId,
         @Valid @RequestBody AddSubscriptionRequest request,
@@ -44,7 +44,7 @@ public class SubscriptionController implements SubscriptionControllerApi {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/api/folders/{folderId}/rss/{subscriptionId}") // TODO: url에서 rss 부분 수정하기 + 프론트
+    @DeleteMapping("/api/folders/{folderId}/subscriptions/{subscriptionId}") // TODO: url에서 rss 부분 수정하기 + 프론트
     public ApplicationResponse<Void> removeSubscriptionToFolder(
         @PathVariable Long folderId,
         @PathVariable Long subscriptionId,


### PR DESCRIPTION
## 🔑 Key Changes
- URL에 있던 어색한 자원 표현 변경
  - `rss` -> `subscription`

|변경 전|변경 후|
|---|---|
|`POST` `/api/folders/{folderId}/rss`|`POST` `/api/folders/{folderId}/subscriptions`|
|`DELETE` `/api/folders/{folderId}/rss/{subscriptionId}`|`DELETE` `/api/folders/{folderId}/subscriptions/{subscriptionId}`|

## 👩‍💻 To Reviewers
- 

## Related to
- #246 
