### PR TITLE
게시글 수집 한 사이클만 실행하기 API 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/admin/business/service/AdminSystemService.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/business/service/AdminSystemService.java
@@ -2,6 +2,7 @@ package com.flytrap.rssreader.api.admin.business.service;
 
 import com.flytrap.rssreader.api.admin.domain.AdminSystemAggregate;
 import com.flytrap.rssreader.api.admin.infrastructure.implementation.AdminSystemCommand;
+import com.flytrap.rssreader.api.post.infrastructure.system.PostCollectSystem;
 import com.flytrap.rssreader.api.post.infrastructure.system.PostCollectionEnableLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ public class AdminSystemService {
 
     private final AdminSystemCommand adminSystemCommand;
     private final PostCollectionEnableLoader postCollectionEnableLoader;
+    private final PostCollectSystem postCollectSystem;
 
     public void startPostCollection() {
         AdminSystemAggregate adminSystemAggregate = adminSystemCommand.read();
@@ -27,6 +29,13 @@ public class AdminSystemService {
 
         adminSystemCommand.save(adminSystemAggregate);
         postCollectionEnableLoader.toDisable();
+    }
+
+    public void startPostCollectionCycle(int batchSize) {
+        if (postCollectionEnableLoader.isEnabled()) {
+            throw new IllegalStateException("게시글 수집 기능이 이미 실행 중 입니다.");
+        }
+        postCollectSystem.collectPosts(batchSize);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.api.admin.presentation.controller;
 
 import com.flytrap.rssreader.api.admin.business.service.AdminSystemService;
+import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionCycleRequest;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
 import com.flytrap.rssreader.api.auth.presentation.dto.LoginRequest;
 import com.flytrap.rssreader.api.auth.presentation.dto.LoginResponse;
@@ -9,6 +10,7 @@ import com.flytrap.rssreader.global.presentation.resolver.AdminLogin;
 import com.flytrap.rssreader.global.properties.AdminProperties;
 import com.flytrap.rssreader.global.properties.AuthProperties;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import javax.security.sasl.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +69,17 @@ public class AdminController {
         adminSystemService.stopPostCollection();
 
         return new ApplicationResponse<>("게시글 수집 기능 중지");
+    }
+
+    @PostMapping("/api/admin/post-collection/cycle")
+    public ApplicationResponse<String> startPostCollectionCycle(
+        @RequestBody @Valid PostCollectionCycleRequest request,
+        @AdminLogin AccountCredentials accountCredentials
+    ) {
+        adminSystemService.startPostCollectionCycle(request.getBatchSize());
+
+        return new ApplicationResponse<>(
+            "게시글 수집 사이클 완료. batchSize: " + request.getBatchSize());
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionCycleRequest.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionCycleRequest.java
@@ -1,0 +1,15 @@
+package com.flytrap.rssreader.api.admin.presentation.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostCollectionCycleRequest {
+
+    @Min(value = 1, message = "batchSize는 음수 값은 허용되지 않습니다.")
+    @Max(value = 100_000, message = "batchSize는 100,000을 초과할 수 없습니다.")
+    private int batchSize = 1;
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.api.post.business.service;
 
 import com.flytrap.rssreader.api.post.infrastructure.system.PostCollectSystem;
+import com.flytrap.rssreader.api.post.infrastructure.system.PostCollectionEnableLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,9 +15,15 @@ public class PostCollectScheduledService {
     private int selectBatchSize;
 
     private final PostCollectSystem postCollectSystem;
+    private final PostCollectionEnableLoader postCollectionEnableLoader;
 
     @Scheduled(fixedDelay = 1000)
     public void collectPostsScheduled() {
+
+        if (postCollectionEnableLoader.isDisabled()) {
+            return;
+        }
+
         postCollectSystem.collectPosts(selectBatchSize);
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
@@ -28,15 +28,10 @@ public class PostCollectSystem {
     private final SubscribeCollectionPriorityQueue collectionQueue;
     private final RssResourceJpaRepository rssResourceRepository;
     private final PostJpaRepository postRepository;
-    private final PostCollectionEnableLoader postCollectionEnableLoader;
     private final RssPostParser postParser;
     private final GlobalEventPublisher globalEventPublisher;
 
     public void collectPosts(int selectBatchSize) {
-
-        if (postCollectionEnableLoader.isDisabled()) {
-            return;
-        }
 
         var now = Instant.now();
         var pageable = PageRequest.of(

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectionEnableLoader.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectionEnableLoader.java
@@ -22,6 +22,10 @@ public class PostCollectionEnableLoader implements CommandLineRunner {
             .isPostCollectionEnabled();
     }
 
+    public boolean isEnabled() {
+        return this.isEnable;
+    }
+
     public boolean isDisabled() {
         return !this.isEnable;
     }


### PR DESCRIPTION
## 🔑 Key Changes
- 게시글 수집 한 사이클만 실행하기 API 추가

## 👩‍💻 To Reviewers
### 게시글 수집 한 사이클만 실행하기 API 추가
|Method|URI|
|---|---|
|`POST`|`/api/admin/post-collection/cycle`|

### Request
|name|type|description|
|---|---|---|
|batchSize|int|한 사이클에 수집할 게시글 개수. (min=1, max=100,000)<br>게시글 수집 기능이 정지된 상태에서만 요청 가능|

## Related to
- close #250 
