### PR TITLE
Folder 2차 리펙토링 및 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     implementation 'com.github.jojoldu.spring-batch-querydsl:spring-batch-querydsl-reader:2.3.3'
     // Prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    // Test Container
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 }
 
 test {

--- a/src/main/java/com/flytrap/rssreader/api/alert/business/event/NewPostAlertEventListener.java
+++ b/src/main/java/com/flytrap/rssreader/api/alert/business/event/NewPostAlertEventListener.java
@@ -2,7 +2,9 @@ package com.flytrap.rssreader.api.alert.business.event;
 
 import com.flytrap.rssreader.api.alert.domain.Alert;
 import com.flytrap.rssreader.api.alert.infrastructure.system.AlertSendSystem;
+import com.flytrap.rssreader.api.folder.domain.Folder;
 import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderQuery;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -23,7 +25,9 @@ public class NewPostAlertEventListener {
         if (!alerts.isEmpty()) {
             alerts.forEach(alert ->
                 alertSendSystem.sendAlertToPlatform(
-                    folderQuery.read(alert.getFolderId()).getName(),
+                    folderQuery.read(alert.getFolderId())
+                        .orElseThrow(() -> new NoSuchDomainException(Folder.class))
+                        .getName(),
                     alert.getWebhookUrl(),
                     event.posts()
                 ));

--- a/src/main/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandService.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandService.java
@@ -8,12 +8,13 @@ import com.flytrap.rssreader.api.folder.domain.FolderId;
 import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
 import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderValidator;
 import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class FolderUpdateService {
+public class FolderCommandService {
 
     private final FolderValidator folderValidator;
     private final FolderCommand folderCommand;
@@ -31,7 +32,8 @@ public class FolderUpdateService {
         if (!folderValidator.isMyOwnFolder(folderId, accountId))
             throw new ForbiddenAccessFolderException(Folder.class);
 
-        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId);
+        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId)
+            .orElseThrow(() -> new NoSuchDomainException(FolderAggregate.class));
         folderAggregate.changeName(folderName);
 
         return folderCommand.update(folderAggregate);
@@ -41,7 +43,8 @@ public class FolderUpdateService {
         if (!folderValidator.isMyOwnFolder(folderId, accountId))
             throw new ForbiddenAccessFolderException(Folder.class);
 
-        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId);
+        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId)
+            .orElseThrow(() -> new NoSuchDomainException(FolderAggregate.class));
 
         folderCommand.delete(folderAggregate);
     }

--- a/src/main/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class FolderReadService {
+public class FolderQueryService {
 
     private final FolderQuery folderQuery;
 

--- a/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/implementatioin/FolderCommand.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/implementatioin/FolderCommand.java
@@ -2,11 +2,10 @@ package com.flytrap.rssreader.api.folder.infrastructure.implementatioin;
 
 import com.flytrap.rssreader.api.folder.domain.FolderAggregate;
 import com.flytrap.rssreader.api.folder.domain.FolderCreate;
-import com.flytrap.rssreader.api.folder.domain.Folder;
 import com.flytrap.rssreader.api.folder.domain.FolderId;
 import com.flytrap.rssreader.api.folder.infrastructure.entity.FolderEntity;
 import com.flytrap.rssreader.api.folder.infrastructure.repository.FolderJpaRepository;
-import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,10 +17,9 @@ public class FolderCommand {
     private final FolderJpaRepository folderJpaRepository;
 
     @Transactional(readOnly = true)
-    public FolderAggregate readAggregate(FolderId folderId) {
-        return folderJpaRepository.findById(folderId.value())
-            .orElseThrow(() -> new NoSuchDomainException(Folder.class))
-            .toAggregate();
+    public Optional<FolderAggregate> readAggregate(FolderId folderId) {
+        return folderJpaRepository.findByIdAndIsDeletedFalse(folderId.value())
+            .map(FolderEntity::toAggregate);
     }
 
     @Transactional

--- a/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/implementatioin/FolderQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/implementatioin/FolderQuery.java
@@ -7,8 +7,8 @@ import com.flytrap.rssreader.api.folder.infrastructure.repository.FolderDslRepos
 import com.flytrap.rssreader.api.folder.infrastructure.repository.FolderJpaRepository;
 import com.flytrap.rssreader.api.shared_member.infrastructure.implementation.SharedMemberQuery;
 import com.flytrap.rssreader.api.subscribe.infrastructure.implement.SubscriptionQuery;
-import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,12 +21,12 @@ public class FolderQuery {
     private final SubscriptionQuery subscriptionQuery;
     private final SharedMemberQuery sharedMemberQuery;
 
-    public Folder read(FolderId folderId) {
+    public Optional<Folder> read(FolderId folderId) {
         return folderJpaRepository.findById(folderId.value())
-            .orElseThrow(() -> new NoSuchDomainException(Folder.class))
-            .toReadonly(
-                subscriptionQuery.readAllByFolder(folderId),
-                sharedMemberQuery.readAllByFolder(folderId)
+            .map(entity ->
+                entity.toReadonly(
+                    subscriptionQuery.readAllByFolder(folderId),
+                    sharedMemberQuery.readAllByFolder(folderId))
             );
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/repository/FolderJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/infrastructure/repository/FolderJpaRepository.java
@@ -1,9 +1,11 @@
 package com.flytrap.rssreader.api.folder.infrastructure.repository;
 
 import com.flytrap.rssreader.api.folder.infrastructure.entity.FolderEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FolderJpaRepository extends JpaRepository<FolderEntity, Long> {
 
+    Optional<FolderEntity> findByIdAndIsDeletedFalse(Long id);
     boolean existsByIdAndAccountIdAndIsDeletedFalse(Long id, Long accountId);
 }

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandController.java
@@ -18,18 +18,16 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/folders")
 public class FolderCommandController implements FolderCommandControllerApi {
 
     private final FolderCommandService folderCommandService;
 
-    @PostMapping
+    @PostMapping("/api/folders")
     @ResponseStatus(HttpStatus.CREATED)
     public ApplicationResponse<FolderUpdateResponse> createNewFolder(
             @Valid @RequestBody FolderUpdateRequest request,
@@ -41,7 +39,7 @@ public class FolderCommandController implements FolderCommandControllerApi {
         return new ApplicationResponse<>(FolderUpdateResponse.from(newFolder));
     }
 
-    @PatchMapping("/{folderId}")
+    @PatchMapping("/api/folders/{folderId}")
     @ResponseStatus(HttpStatus.OK)
     public ApplicationResponse<FolderUpdateResponse> updateFolder(
             @Valid @RequestBody FolderUpdateRequest request,
@@ -55,7 +53,7 @@ public class FolderCommandController implements FolderCommandControllerApi {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/{folderId}")
+    @DeleteMapping("/api/folders/{folderId}")
     public ApplicationResponse<Void> deleteFolder(
             @PathVariable Long folderId,
             @Login AccountCredentials accountCredentials) {

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandController.java
@@ -2,10 +2,10 @@ package com.flytrap.rssreader.api.folder.presentation.controller;
 
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
-import com.flytrap.rssreader.api.folder.business.service.FolderUpdateService;
+import com.flytrap.rssreader.api.folder.business.service.FolderCommandService;
 import com.flytrap.rssreader.api.folder.domain.FolderAggregate;
 import com.flytrap.rssreader.api.folder.domain.FolderId;
-import com.flytrap.rssreader.api.folder.presentation.controller.swagger.FolderUpdateControllerApi;
+import com.flytrap.rssreader.api.folder.presentation.controller.swagger.FolderCommandControllerApi;
 import com.flytrap.rssreader.api.folder.presentation.dto.FolderUpdateRequest;
 import com.flytrap.rssreader.api.folder.presentation.dto.FolderUpdateResponse;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
@@ -25,9 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/folders")
-public class FolderUpdateController implements FolderUpdateControllerApi {
+public class FolderCommandController implements FolderCommandControllerApi {
 
-    private final FolderUpdateService folderUpdateService;
+    private final FolderCommandService folderCommandService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -35,7 +35,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
             @Valid @RequestBody FolderUpdateRequest request,
             @Login AccountCredentials accountCredentials) {
 
-        FolderAggregate newFolder = folderUpdateService
+        FolderAggregate newFolder = folderCommandService
             .createNewFolder(new AccountId(accountCredentials.id().value()), request.name());
 
         return new ApplicationResponse<>(FolderUpdateResponse.from(newFolder));
@@ -48,7 +48,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
             @PathVariable Long folderId,
             @Login AccountCredentials accountCredentials) {
 
-        FolderAggregate folder = folderUpdateService
+        FolderAggregate folder = folderCommandService
             .updateFolder(new AccountId(accountCredentials.id().value()), new FolderId(folderId), request.name());
 
         return new ApplicationResponse<>(FolderUpdateResponse.from(folder));
@@ -60,7 +60,7 @@ public class FolderUpdateController implements FolderUpdateControllerApi {
             @PathVariable Long folderId,
             @Login AccountCredentials accountCredentials) {
 
-        folderUpdateService.deleteFolder(new AccountId(accountCredentials.id().value()), new FolderId(folderId));
+        folderCommandService.deleteFolder(new AccountId(accountCredentials.id().value()), new FolderId(folderId));
 
         return new ApplicationResponse<>(null);
     }

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryController.java
@@ -10,17 +10,15 @@ import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.global.presentation.resolver.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/folders")
 public class FolderQueryController implements FolderQueryControllerApi {
 
     private final FolderQueryService folderQueryService;
 
-    @GetMapping
+    @GetMapping("/api/folders")
     public ApplicationResponse<MyFoldersResponse> getMyFolders(@Login AccountCredentials accountSession) {
 
         AccessibleFolders accessibleFolders = folderQueryService.getMyFolders(new AccountId(accountSession.id().value()));

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryController.java
@@ -2,9 +2,9 @@ package com.flytrap.rssreader.api.folder.presentation.controller;
 
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
-import com.flytrap.rssreader.api.folder.business.service.FolderReadService;
+import com.flytrap.rssreader.api.folder.business.service.FolderQueryService;
 import com.flytrap.rssreader.api.folder.domain.AccessibleFolders;
-import com.flytrap.rssreader.api.folder.presentation.controller.swagger.FolderReadControllerApi;
+import com.flytrap.rssreader.api.folder.presentation.controller.swagger.FolderQueryControllerApi;
 import com.flytrap.rssreader.api.folder.presentation.dto.MyFoldersResponse;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.global.presentation.resolver.Login;
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/folders")
-public class FolderReadController implements FolderReadControllerApi {
+public class FolderQueryController implements FolderQueryControllerApi {
 
-    private final FolderReadService folderReadService;
+    private final FolderQueryService folderQueryService;
 
     @GetMapping
     public ApplicationResponse<MyFoldersResponse> getMyFolders(@Login AccountCredentials accountSession) {
 
-        AccessibleFolders accessibleFolders = folderReadService.getMyFolders(new AccountId(accountSession.id().value()));
+        AccessibleFolders accessibleFolders = folderQueryService.getMyFolders(new AccountId(accountSession.id().value()));
 
         return new ApplicationResponse<>(MyFoldersResponse.from(accessibleFolders));
     }

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/swagger/FolderCommandControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/swagger/FolderCommandControllerApi.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-public interface FolderUpdateControllerApi {
+public interface FolderCommandControllerApi {
 
     @Operation(summary = "새로운 폴더 추가하기", description = "새로운 폴더를 추가한다.")
     @ApiResponses(value = {

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/swagger/FolderQueryControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/controller/swagger/FolderQueryControllerApi.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
-public interface FolderReadControllerApi {
+public interface FolderQueryControllerApi {
 
     @Operation(summary = "폴더 목록 불러오기", description = "현재 회원이 생성한 폴더 목록을 반환한다.")
     @ApiResponses(value = {

--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/dto/FolderUpdateRequest.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/dto/FolderUpdateRequest.java
@@ -3,7 +3,7 @@ package com.flytrap.rssreader.api.folder.presentation.dto;
 import jakarta.validation.constraints.Size;
 
 public record FolderUpdateRequest(
-    @Size(min = 1, max = 255) String name
+    @Size(min = 1, max = 255, message = "폴더명은 1자 이상 255자 이하여야 합니다.") String name
 ) {
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/shared_member/business/service/SharedMemberService.java
+++ b/src/main/java/com/flytrap/rssreader/api/shared_member/business/service/SharedMemberService.java
@@ -12,6 +12,7 @@ import com.flytrap.rssreader.api.shared_member.infrastructure.implementation.Sha
 import com.flytrap.rssreader.api.shared_member.infrastructure.implementation.SharedMemberValidator;
 import com.flytrap.rssreader.global.exception.domain.DuplicateDomainException;
 import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import com.flytrap.rssreader.global.exception.domain.NotFolderOwnerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -42,7 +43,8 @@ public class SharedMemberService {
         SharedMember sharedMember = sharedMemberCommand
             .create(new SharedMemberCreate(folderId, inviteeId));
 
-        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId);
+        FolderAggregate folderAggregate = folderCommand.readAggregate(folderId)
+            .orElseThrow(() -> new NoSuchDomainException(FolderAggregate.class));
         folderAggregate.toShared();
         folderCommand.update(folderAggregate);
 
@@ -60,7 +62,8 @@ public class SharedMemberService {
         sharedMemberCommand.deleteBy(folderId, accountId);
 
         if (sharedMemberValidator.hasNoSharedMembersByFolder(folderId)) {
-            FolderAggregate folderAggregate = folderCommand.readAggregate(folderId);
+            FolderAggregate folderAggregate = folderCommand.readAggregate(folderId)
+                .orElseThrow(() -> new NoSuchDomainException(FolderAggregate.class));
             folderAggregate.toPrivate();
             folderCommand.update(folderAggregate);
         }
@@ -78,7 +81,8 @@ public class SharedMemberService {
         sharedMemberCommand.deleteBy(folderId, inviteeId);
 
         if (sharedMemberValidator.hasNoSharedMembersByFolder(folderId)) {
-            FolderAggregate folderAggregate = folderCommand.readAggregate(folderId);
+            FolderAggregate folderAggregate = folderCommand.readAggregate(folderId)
+                .orElseThrow(() -> new NoSuchDomainException(FolderAggregate.class));
             folderAggregate.toPrivate();
             folderCommand.update(folderAggregate);
         }

--- a/src/main/java/com/flytrap/rssreader/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flytrap/rssreader/global/exception/GlobalExceptionHandler.java
@@ -21,11 +21,20 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({DuplicateKeyException.class, MethodArgumentNotValidException.class, IllegalArgumentException.class})
+    @ExceptionHandler({
+        DuplicateKeyException.class, IllegalArgumentException.class})
     public ErrorResponse handleBadInputException(RuntimeException e) {
         e.printStackTrace();
         log.error(e.getMessage());
         return ErrorResponse.occur("input error", e);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    public ErrorResponse handleBadInputException(MethodArgumentNotValidException e) {
+        e.printStackTrace();
+        log.error(e.getMessage());
+        return ErrorResponse.occur(Objects.requireNonNull(e.getFieldError()));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -1,31 +1,29 @@
-DROP DATABASE IF EXISTS `rss_reader`;
-CREATE SCHEMA IF NOT EXISTS `rss_reader` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
-USE `rss_reader`;
-CREATE TABLE IF NOT EXISTS `member`
+CREATE TABLE IF NOT EXISTS `account`
 (
-    `id`           bigint          NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name`         varchar(255)    NOT NULL,
-    `email`        varchar(255)    NOT NULL,
-    `profile`      varchar(2500)   NOT NULL,
-    `oauth_pk`     bigint          NOT NULL,
-    `oauth_server` enum ('GITHUB') NOT NULL,
-    `created_at`   date            NOT NULL
+    `id`           bigint                   NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name`         varchar(255)             NOT NULL,
+    `email`        varchar(255)             NOT NULL,
+    `profile`      varchar(2500)            NOT NULL,
+    `oauth_pk`     bigint                   NOT NULL,
+    `oauth_server` enum ('GITHUB')          NOT NULL,
+    `roll`         enum('ADMIN','GENERAL')  NOT NULL,
+    `created_at`   date                     NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS `rss_subscribe`
+CREATE TABLE IF NOT EXISTS `rss_source`
 (
-    `id`          bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `title` varchar(2500) NOT NULL,
-    `url`         varchar(2500) NOT NULL,
-    `platform`    varchar(25)   NOT NULL
+    `id`                bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `title`             varchar(2500),
+    `url`               varchar(2500) NOT NULL,
+    `platform`          varchar(25),
+    `last_collected_at` datetime(6)
 );
 
-CREATE TABLE IF NOT EXISTS `rss_post`
+CREATE TABLE IF NOT EXISTS `post`
 (
     `id`            bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `guid`          varchar(2500) NOT NULL,
-    `subscribe_id`  bigint        NOT NULL,
+    `rss_source_id` bigint        NOT NULL,
     `title`         varchar(2500) NOT NULL,
     `thumbnail_url` varchar(2500),
     `description`   longtext      NOT NULL,
@@ -36,61 +34,53 @@ CREATE TABLE IF NOT EXISTS `open`
 (
     `id`           bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `post_id`      bigint        NOT NULL,
-    `member_id`    bigint        NOT NULL
+    `account_id`   bigint        NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS `folder`
 (
-    `id`        bigint      NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name`      varchar(255) NOT NULL,
-    `member_id` bigint      NOT NULL,
-    `is_shared` tinyint(1)  NOT NULL DEFAULT 0,
-    `is_deleted` tinyint(1) NOT NULL DEFAULT 0
+    `id`         bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name`       varchar(255) NOT NULL,
+    `account_id` bigint       NOT NULL,
+    `is_shared`  tinyint(1)   NOT NULL DEFAULT 0,
+    `is_deleted` tinyint(1)   NOT NULL DEFAULT 0
 );
 
-CREATE TABLE IF NOT EXISTS `folder_subscribe`
+CREATE TABLE IF NOT EXISTS `subscription`
 (
-    `id`                 bigint     NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `subscribe_id`      bigint      NOT NULL,
-    `folder_id`         bigint      NOT NULL,
-    `description`       varchar(2500) NOT NULL default 'empty'
+    `id`                bigint      NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `rss_source_id`     bigint      NOT NULL,
+    `folder_id`         bigint      NOT NULL
  );
 
-CREATE TABLE IF NOT EXISTS `folder_member`
+CREATE TABLE IF NOT EXISTS `shared_member`
 (
-    `id`                 bigint     NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `folder_id`         bigint      NOT NULL,
-    `member_id`         bigint      NOT NULL
+    `id`            bigint  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `folder_id`     bigint  NOT NULL,
+    `account_id`    bigint  NOT NULL
  );
 
-CREATE TABLE IF NOT EXISTS `bookmark` (
-    `id`	    bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `member_id`	bigint	NOT NULL,
-    `post_id`	bigint	NOT NULL
-);
-
-
-CREATE TABLE IF NOT EXISTS `post_react` (
-    `id`	    bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `member_id`	bigint	NOT NULL,
-    `post_id`	bigint	NOT NULL,
-    `emoji`     bigint	NOT NULL,
-    FOREIGN KEY (`member_id`) REFERENCES `member`(`id`),
-    FOREIGN KEY (`post_id`) REFERENCES `rss_post`(`id`)
-);
-
-CREATE TABLE IF NOT EXISTS `alert_platform` (
-    `id`	    bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `platform`	varchar(25)	NOT NULL,
-    `signature_url`	varchar(2500)	NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS `alert` (
+CREATE TABLE IF NOT EXISTS `bookmark`
+(
     `id`	        bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `member_id`	    bigint	NOT NULL,
-    `folder_id`	    bigint	NOT NULL,
-    `platform_id`    bigint	NOT NULL,
-    `webhook_url`   varchar(2500)   NOT NULL
+    `account_id`	bigint	NOT NULL,
+    `post_id` 	    bigint	NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS `alert`
+(
+    `id`	            bigint	                    NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `account_id`	    bigint	                    NOT NULL,
+    `folder_id`	        bigint	                    NOT NULL,
+    `webhook_url`       varchar(2500)               NOT NULL,
+    `alert_platform`    enum('DISCORD', 'SLACK')
+);
+
+CREATE TABLE IF NOT EXISTS `admin_system`
+(
+    `id`                        bigint  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `post_collection_enabled`   tinyint(1)   NOT NULL DEFAULT 0,
+    `post_collection_delay`     bigint
 );
 
 CREATE TABLE IF NOT EXISTS `rss_post_stat`

--- a/src/test/java/com/flytrap/rssreader/CustomControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/CustomControllerTest.java
@@ -1,0 +1,24 @@
+package com.flytrap.rssreader;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+@Sql(scripts = "/reset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public @interface CustomControllerTest {
+
+}

--- a/src/test/java/com/flytrap/rssreader/CustomServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/CustomServiceTest.java
@@ -14,6 +14,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest
 @Testcontainers
 @Sql(scripts = "/reset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-public @interface CustomTestConfig {
+public @interface CustomServiceTest {
 
 }

--- a/src/test/java/com/flytrap/rssreader/CustomTestConfig.java
+++ b/src/test/java/com/flytrap/rssreader/CustomTestConfig.java
@@ -1,0 +1,19 @@
+package com.flytrap.rssreader;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@Testcontainers
+@Sql(scripts = "/reset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public @interface CustomTestConfig {
+
+}

--- a/src/test/java/com/flytrap/rssreader/RssReaderApplicationTests.java
+++ b/src/test/java/com/flytrap/rssreader/RssReaderApplicationTests.java
@@ -1,6 +1,5 @@
 package com.flytrap.rssreader;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest

--- a/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandServiceTest.java
@@ -1,0 +1,179 @@
+package com.flytrap.rssreader.api.folder.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.flytrap.rssreader.CustomTestConfig;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.folder.domain.FolderCreate;
+import com.flytrap.rssreader.api.folder.domain.FolderId;
+import com.flytrap.rssreader.api.folder.domain.SharedStatus;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
+import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@CustomTestConfig
+class FolderCommandServiceTest {
+
+    @Autowired
+    FolderCommandService folderCommandService;
+    @Autowired
+    FolderCommand folderCommand;
+
+    @Nested
+    class CreateNewFolder {
+
+        @Test
+        void 새_폴더를_생성할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var folderName = "폴더 이름";
+
+            // when
+            var newFolder
+                = folderCommandService.createNewFolder(accountId, folderName);
+
+            // then
+            assertAll(
+                () -> assertThat(newFolder.getId()).isNotNull(),
+                () -> assertThat(newFolder)
+                    .hasFieldOrPropertyWithValue("name", folderName)
+                    .hasFieldOrPropertyWithValue("ownerId", accountId)
+                    .hasFieldOrPropertyWithValue("sharedStatus", SharedStatus.PRIVATE)
+            );
+        }
+    }
+
+    @Nested
+    class UpdateFolder {
+
+        @Test
+        void 폴더_주인은_폴더명을_변경할_수_있다() {
+            // given
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+
+            var ownerId = folderAggregate.getOwnerId();
+            var folderId = folderAggregate.getId();
+            var folderName = "수정할 폴더 이름";
+
+            // when
+            var updatedFolder = folderCommandService
+                .updateFolder(ownerId, folderId, folderName);
+
+            // then
+            assertAll(
+                () -> assertThat(updatedFolder)
+                    .hasFieldOrPropertyWithValue("id", folderId)
+                    .hasFieldOrPropertyWithValue("ownerId", ownerId)
+                    .hasFieldOrPropertyWithValue("name", folderName)
+            );
+        }
+
+        @Test
+        void 폴더_주인이_아니면_폴더명을_변경할_수_없다() {
+            // given
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+
+            var folderId = folderAggregate.getId();
+            var folderName = "수정할 폴더 이름";
+            var anotherAccountId = new AccountId(99L);
+
+            // when
+            Executable updateFolderExecutable = ()
+                -> folderCommandService.updateFolder(anotherAccountId, folderId, folderName);
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, updateFolderExecutable);
+        }
+
+        @Test
+        void 존재하지_않는_폴더는_변경할_수_없다() {
+            // given
+            var accountId = new AccountId(1L);
+            var folderId = new FolderId(99L);
+            var folderName = "수정할 폴더 이름";
+
+            // when
+            Executable updateFolderExecutable = ()
+                -> folderCommandService.updateFolder(accountId, folderId, folderName);
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, updateFolderExecutable);
+        }
+    }
+
+    @Nested
+    class DeleteFolder {
+
+        @Test
+        void 폴더_주인은_폴더를_삭제할_수_있다() {
+            // given
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+
+            var ownerId = folderAggregate.getOwnerId();
+            var folderId = folderAggregate.getId();
+
+            // when
+            folderCommandService.deleteFolder(ownerId, folderId);
+
+            // then
+            assertThat(folderCommand.readAggregate(folderId).isEmpty())
+                .isTrue();
+        }
+
+        @Test
+        void 폴더_주인이_아니면_폴더를_삭제할_수_없다() {
+            // given
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+
+            var folderId = folderAggregate.getId();
+            var anotherAccountId = new AccountId(99L);
+
+            // when
+            Executable deleteFolderExecutable = ()
+                -> folderCommandService.deleteFolder(anotherAccountId, folderId);
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, deleteFolderExecutable);
+        }
+
+        @Test
+        void 존재하지_않는_폴더는_삭제할_수_없다() {
+            // given
+            var accountId = new AccountId(1L);
+            var folderId = new FolderId(99L);
+
+            // when
+            Executable deleteFolderExecutable = ()
+                -> folderCommandService.deleteFolder(accountId, folderId);
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, deleteFolderExecutable);
+        }
+    }
+
+}

--- a/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderCommandServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.flytrap.rssreader.CustomTestConfig;
+import com.flytrap.rssreader.CustomServiceTest;
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.folder.domain.FolderCreate;
 import com.flytrap.rssreader.api.folder.domain.FolderId;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@CustomTestConfig
+@CustomServiceTest
 class FolderCommandServiceTest {
 
     @Autowired

--- a/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryServiceTest.java
@@ -1,0 +1,130 @@
+package com.flytrap.rssreader.api.folder.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.flytrap.rssreader.CustomTestConfig;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.folder.domain.FolderCreate;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@CustomTestConfig
+class FolderQueryServiceTest {
+
+    @Autowired
+    FolderQueryService folderQueryService;
+    @Autowired
+    FolderCommand folderCommand;
+
+    @Nested
+    class GetMyFolders {
+
+        @Test
+        void 회원은_접근_가능한_폴더_목록을_불러올_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var privateFolder1 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 1")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var privateFolder2 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 2")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var privateFolder3 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 3")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var sharedFolder1 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 4")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            sharedFolder1.toShared();
+            folderCommand.update(sharedFolder1);
+            var sharedFolder2 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 5")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            sharedFolder2.toShared();
+            folderCommand.update(sharedFolder2);
+
+            // when
+            var accessibleFolders = folderQueryService.getMyFolders(accountId);
+
+            // then
+            assertAll(
+                () -> assertThat(accessibleFolders.privateFolders()).hasSize(3),
+                () -> assertThat(accessibleFolders.sharedFolder()).hasSize(2)
+            );
+        }
+
+        @Test
+        void 개인_폴더와_공유_폴더를_분리해서_불러온다() {
+            // given
+            var accountId = new AccountId(1L);
+            var privateFolder1 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 1")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var privateFolder2 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 2")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var privateFolder3 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 3")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            var sharedFolder1 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 4")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            sharedFolder1.toShared();
+            folderCommand.update(sharedFolder1);
+            var sharedFolder2 = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름 5")
+                    .ownerId(new AccountId(1L))
+                    .build()
+                );
+            sharedFolder2.toShared();
+            folderCommand.update(sharedFolder2);
+
+            // when
+            var accessibleFolders = folderQueryService.getMyFolders(accountId);
+            var privateFolders = accessibleFolders.privateFolders();
+            var sharedFolders = accessibleFolders.sharedFolder();
+
+            // then
+            assertAll(
+                () -> assertThat(privateFolders.get(0).isPrivate()).isTrue(),
+                () -> assertThat(privateFolders.get(1).isPrivate()).isTrue(),
+                () -> assertThat(privateFolders.get(2).isPrivate()).isTrue(),
+                () -> assertThat(sharedFolders.get(0).isShared()).isTrue(),
+                () -> assertThat(sharedFolders.get(1).isShared()).isTrue()
+            );
+        }
+    }
+
+
+}

--- a/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/business/service/FolderQueryServiceTest.java
@@ -3,7 +3,7 @@ package com.flytrap.rssreader.api.folder.business.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.flytrap.rssreader.CustomTestConfig;
+import com.flytrap.rssreader.CustomServiceTest;
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.folder.domain.FolderCreate;
 import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@CustomTestConfig
+@CustomServiceTest
 class FolderQueryServiceTest {
 
     @Autowired

--- a/src/test/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderCommandControllerTest.java
@@ -1,0 +1,364 @@
+package com.flytrap.rssreader.api.folder.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flytrap.rssreader.CustomControllerTest;
+import com.flytrap.rssreader.api.account.domain.Account;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.account.domain.AccountName;
+import com.flytrap.rssreader.api.account.domain.AccountRoll;
+import com.flytrap.rssreader.api.account.domain.AuthProvider;
+import com.flytrap.rssreader.api.account.infrastructure.implement.AccountCommand;
+import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.api.folder.domain.FolderCreate;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
+import com.flytrap.rssreader.api.folder.presentation.dto.FolderUpdateRequest;
+import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
+import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
+import java.time.Instant;
+import javax.security.sasl.AuthenticationException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomControllerTest
+class FolderCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthorizationArgumentResolver authorizationArgumentResolver;
+
+    @MockBean
+    AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
+
+    @Autowired
+    FolderCommand folderCommand;
+
+    @Autowired
+    AccountCommand accountCommand;
+
+    @Nested
+    class 새_폴더_생성_API {
+
+        @Test
+        void 새_폴더_생성에_성공하면_201응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("새 폴더");
+
+            // when, then
+            mockMvc.perform(post("/api/folders")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.folderId").value("1"))
+                .andExpect(jsonPath("$.data.folderName").value("새 폴더"));
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            var request = new FolderUpdateRequest("새 폴더");
+
+            // when, then
+            mockMvc.perform(post("/api/folders")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").hasJsonPath())
+                .andExpect(jsonPath("$.message").hasJsonPath());
+        }
+
+        @Test
+        void 새_폴더_생성시_폴더명이_255자_보다_크면_400응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("A".repeat(256));
+
+            // when, then
+            mockMvc.perform(post("/api/folders")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode")
+                    .value("Input_FieldError_name"))
+                .andExpect(jsonPath("$.message")
+                    .value("폴더명은 1자 이상 255자 이하여야 합니다."));
+        }
+
+        @Test
+        void 새_폴더_생성시_폴더명이_한_글자_미만이면_400응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("");
+
+            // when, then
+            mockMvc.perform(post("/api/folders")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode")
+                    .value("Input_FieldError_name"))
+                .andExpect(jsonPath("$.message")
+                    .value("폴더명은 1자 이상 255자 이하여야 합니다."));
+        }
+
+    }
+
+    @Nested
+    class 폴더_제목_수정_API {
+
+        @Test
+        void 폴더_제목_수정_성공시_200응답을_반환한다() throws Exception {
+            // given
+            var account = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원1")).email("example@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(account.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("수정할 폴더명");
+
+            // when, then
+            mockMvc.perform(patch("/api/folders/{folderId}", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.folderId").value("1"))
+                .andExpect(jsonPath("$.data.folderName").value("수정할 폴더명"));
+        }
+
+        @Test
+        void 폴더의_소유자가_아닐_경우_403응답을_반환한다() throws Exception {
+            // given
+            var folderOwner = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("폴더 주인")).email("example1@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var anotherAccount = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원2")).email("example2@email.com").profile("url")
+                    .providerKey(22222).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(folderOwner.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(anotherAccount.getId(), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("수정할 폴더명");
+
+            // when, then
+            mockMvc.perform(patch("/api/folders/{folderId}", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").hasJsonPath())
+                .andExpect(jsonPath("$.message").hasJsonPath());
+        }
+
+        @Test
+        void 폴더_수정시_폴더명이_255자_보다_크면_400응답을_반환한다() throws Exception {
+            // given
+            var account = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원1")).email("example@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(account.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("A".repeat(256));
+
+            // when, then
+            mockMvc.perform(patch("/api/folders/{folderId}", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode")
+                    .value("Input_FieldError_name"))
+                .andExpect(jsonPath("$.message")
+                    .value("폴더명은 1자 이상 255자 이하여야 합니다."));
+        }
+
+        @Test
+        void 폴더_수정시_폴더명이_한_글자_미만이면_400응답을_반환한다() throws Exception {
+            // given
+            var account = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원1")).email("example@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(account.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            var request = new FolderUpdateRequest("");
+
+            // when, then
+            mockMvc.perform(patch("/api/folders/{folderId}", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode")
+                    .value("Input_FieldError_name"))
+                .andExpect(jsonPath("$.message")
+                    .value("폴더명은 1자 이상 255자 이하여야 합니다."));
+        }
+    }
+
+    @Nested
+    class 폴더_삭제_API {
+
+        @Test
+        void 폴더_삭제_성공시_204응답을_반환한다() throws Exception {
+            // given
+            var account = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원1")).email("example@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(account.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            // when, then
+            mockMvc.perform(delete("/api/folders/{folderId}", 1))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 폴더의_소유자가_아닐_경우_403응답을_반환한다() throws Exception {
+            // given
+            var folderOwner = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("폴더 주인")).email("example1@email.com").profile("url")
+                    .providerKey(11111).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var anotherAccount = accountCommand
+                .create(Account.builder()
+                    .name(new AccountName("회원2")).email("example2@email.com").profile("url")
+                    .providerKey(22222).authProvider(AuthProvider.GITHUB).roll(AccountRoll.GENERAL)
+                    .createdAt(Instant.now())
+                    .build()
+                );
+            var folderAggregate = folderCommand
+                .create(FolderCreate.builder()
+                    .name("폴더 이름")
+                    .ownerId(folderOwner.getId())
+                    .build()
+                );
+
+            var accountCredentials = new AccountCredentials(anotherAccount.getId(), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            // when, then
+            mockMvc.perform(delete("/api/folders/{folderId}", 1))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").hasJsonPath())
+                .andExpect(jsonPath("$.message").hasJsonPath());
+        }
+
+    }
+
+}

--- a/src/test/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/folder/presentation/controller/FolderQueryControllerTest.java
@@ -1,0 +1,70 @@
+package com.flytrap.rssreader.api.folder.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flytrap.rssreader.CustomControllerTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.account.domain.AccountRoll;
+import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
+import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
+import javax.security.sasl.AuthenticationException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomControllerTest
+class FolderQueryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthorizationArgumentResolver authorizationArgumentResolver;
+
+    @MockBean
+    AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
+
+    @Nested
+    class 내_폴더_조회_API {
+
+        @Test
+        void 조회_성공시_200응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            // when, then
+            mockMvc.perform(get("/api/folders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.folders.PRIVATE").hasJsonPath())
+                .andExpect(jsonPath("$.data.folders.SHARED").hasJsonPath());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            // when, then
+            mockMvc.perform(get("/api/folders"))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8.0.34:///test?TC_INITSCRIPT=file:src/main/resources/db/schema.sql
+    username: test
+    password: test
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:/db/data.sql
+
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        highlight_sql: true
+
+collector:
+  subscribe-queue:
+    select-batch-size: 50
+
+oauth:
+  github:
+    client-id: string
+    client-secret: string
+    redirect-uri: string
+    user-resource-uri: string
+    user-resource-email-uri: string
+    access-token-uri: string

--- a/src/test/resources/db/data.sql
+++ b/src/test/resources/db/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO `admin_system`(post_collection_enabled, post_collection_delay)
+VALUES (false, 1000);

--- a/src/test/resources/reset.sql
+++ b/src/test/resources/reset.sql
@@ -1,0 +1,11 @@
+TRUNCATE TABLE `account`;
+TRUNCATE TABLE `admin_system`;
+TRUNCATE TABLE `alert`;
+TRUNCATE TABLE `bookmark`;
+TRUNCATE TABLE `folder`;
+TRUNCATE TABLE `open`;
+TRUNCATE TABLE `post`;
+TRUNCATE TABLE `rss_source`;
+TRUNCATE TABLE `shared_member`;
+TRUNCATE TABLE `subscription`;
+TRUNCATE TABLE `rss_post_stat`;


### PR DESCRIPTION
# 🔑 Key Changes
- 

# 👩‍💻 To Reviewers
- implement layer에서 단일 read시 Optional 반환
  - service layer에서 도메인 예외 반환
- 용어 변경: Read, Update -> Query, Command

## FolderQueryController 테스트 케이스

### 내 폴더 조회 API
- 조회 성공시 200응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다

## FolderCommandController 테스트 케이스

### 새 폴더 생성 API
- 새 폴더 생성에 성공하면 201응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다
- 새 폴더 생성시 폴더명이 255자 보다 크면 400응답을 반환한다
- 새 폴더 생성시 폴더명이 한 글자 미만이면 400응답을 반환한다

### 폴더 제목 수정 API
- 폴더 제목 수정 성공시 200응답을 반환한다
- 폴더의 소유자가 아닐 경우 403응답을 반환한다
- 폴더 수정시 폴더명이 255자 보다 크면 400응답을 반환한다
- 폴더 수정시 폴더명이 한 글자 미만이면 400응답을 반환한다

### 폴더 삭제 API
- 폴더 삭제 성공시 204응답을 반환한다
- 폴더의 소유자가 아닐 경우 403응답을 반환한다

## FolderQueryService 테스트 케이스

### GetMyFolders
- 회원은 접근 가능한 폴더 목록을 불러올 수 있다
- 개인 폴더와 공유 폴더를 분리해서 불러온다

## FolderCommandService 테스트 케이스

### CreateNewFolder
- 새 폴더를 생성할 수 있다

### UpdateFolder
- 폴더 주인은 폴더명을 변경할 수 있다
- 폴더 주인이 아니면 폴더명을 변경할 수 없다
- 존재하지 않는 폴더는 변경할 수 없다

### DeleteFolder
- 폴더 주인은 폴더를 삭제할 수 있다
- 폴더 주인이 아니면 폴더를 삭제할 수 없다
- 존재하지 않는 폴더는 삭제할 수 없다

# Related to
- #258 
