### PR TITLE
Post 2차 리펙토링 및 테스트 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
@@ -4,6 +4,7 @@ import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.post.domain.PostAggregate;
 import com.flytrap.rssreader.api.post.domain.PostId;
 import com.flytrap.rssreader.api.post.infrastructure.implementation.PostCommand;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,21 +15,24 @@ public class PostCommandService {
     private final PostCommand postCommand;
 
     public void unmarkAsOpen(AccountId accountId, PostId postId) {
-        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId);
+        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId)
+            .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
         postAggregate.unmarkAsOpened();
 
         postCommand.updateOnlyOpen(postAggregate, accountId);
     }
 
     public void markAsBookmark(AccountId accountId, PostId postId) {
-        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId);
+        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId)
+            .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
         postAggregate.markAsBookmarked();
 
         postCommand.updateOnlyOpen(postAggregate, accountId);
     }
 
     public void unmarkAsBookmark(AccountId accountId, PostId postId) {
-        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId);
+        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId)
+            .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
         postAggregate.unmarkAsBookmarked();
 
         postCommand.updateOnlyBookmark(postAggregate, accountId);

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
@@ -27,7 +27,7 @@ public class PostCommandService {
             .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
         postAggregate.markAsBookmarked();
 
-        postCommand.updateOnlyOpen(postAggregate, accountId);
+        postCommand.updateOnlyBookmark(postAggregate, accountId);
     }
 
     public void unmarkAsBookmark(AccountId accountId, PostId postId) {

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCommandService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PostUpdateService {
+public class PostCommandService {
 
     private final PostCommand postCommand;
 

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListQueryService.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @AllArgsConstructor
 @Service
-public class PostListReadService {
+public class PostListQueryService {
 
     private final FolderValidator folderValidator;
     private final SubscriptionQuery subscriptionQuery;

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PostReadService {
+public class PostQueryService {
 
     private final PostCommand postCommand;
     private final RssSourceQuery rssSourceQuery;

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
@@ -9,6 +9,7 @@ import com.flytrap.rssreader.api.post.infrastructure.implementation.PostCommand;
 import com.flytrap.rssreader.api.subscribe.domain.RssSource;
 import com.flytrap.rssreader.api.subscribe.infrastructure.implement.RssSourceQuery;
 import com.flytrap.rssreader.global.event.GlobalEventPublisher;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +23,8 @@ public class PostQueryService {
 
     public Post viewPost(AccountId accountId, PostId postId) {
 
-        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId);
+        PostAggregate postAggregate = postCommand.readAggregate(postId, accountId)
+            .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
         RssSource rssSource = rssSourceQuery.read(postAggregate.getRssSourceId());
 
         globalEventPublisher.publish(new PostOpenEvent(postAggregate, accountId));

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
@@ -10,8 +10,8 @@ import com.flytrap.rssreader.api.post.domain.PostId;
 import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
 import com.flytrap.rssreader.api.post.infrastructure.output.PostSummaryOutput;
 import com.flytrap.rssreader.api.post.infrastructure.repository.BookmarkJpaRepository;
+import com.flytrap.rssreader.api.post.infrastructure.repository.PostDslRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostJpaRepository;
-import com.flytrap.rssreader.api.post.infrastructure.repository.PostListReadRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostOpenJpaRepository;
 import com.flytrap.rssreader.api.subscribe.domain.RssSource;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
@@ -31,7 +31,7 @@ public class PostQuery {
     private final PostJpaRepository postJpaRepository;
     private final BookmarkJpaRepository bookmarkJpaRepository;
     private final PostOpenJpaRepository postOpenJpaRepository;
-    private final PostListReadRepository postListReadRepository;
+    private final PostDslRepository postDslRepository;
     private final RssResourceJpaRepository rssResourceJpaRepository;
 
     @Transactional(readOnly = true)
@@ -54,7 +54,7 @@ public class PostQuery {
     @Transactional(readOnly = true)
     public List<Post> readAllByAccount(AccountId accountId, PostFilter postFilter,
         Pageable pageable) {
-        return postListReadRepository
+        return postDslRepository
             .findAllByAccount(accountId.value(), postFilter, pageable)
             .stream().map(PostSummaryOutput::toReadOnly).toList();
     }
@@ -62,7 +62,7 @@ public class PostQuery {
     @Transactional(readOnly = true)
     public List<Post> readAllByFolder(AccountId accountId, FolderId folderId, PostFilter postFilter,
         Pageable pageable) {
-        return postListReadRepository
+        return postDslRepository
             .findAllByFolder(accountId.value(), folderId.value(), postFilter, pageable)
             .stream().map(PostSummaryOutput::toReadOnly).toList();
     }
@@ -70,7 +70,7 @@ public class PostQuery {
     @Transactional(readOnly = true)
     public List<Post> readAllBySubscription(AccountId accountId, RssSourceId rssSourceId,
         PostFilter postFilter, Pageable pageable) {
-        return postListReadRepository.findAllBySubscription(accountId.value(),
+        return postDslRepository.findAllBySubscription(accountId.value(),
                 rssSourceId.value(), postFilter, pageable).stream()
             .map(PostSummaryOutput::toReadOnly).toList();
     }
@@ -78,7 +78,7 @@ public class PostQuery {
     @Transactional(readOnly = true)
     public List<Post> readAllBookmarked(AccountId accountId, PostFilter postFilter,
         Pageable pageable) {
-        return postListReadRepository.findAllBookmarked(accountId.value(), postFilter, pageable)
+        return postDslRepository.findAllBookmarked(accountId.value(), postFilter, pageable)
             .stream().map(PostSummaryOutput::toReadOnly).toList();
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
@@ -7,18 +7,15 @@ import com.flytrap.rssreader.api.post.domain.Open;
 import com.flytrap.rssreader.api.post.domain.Post;
 import com.flytrap.rssreader.api.post.domain.PostFilter;
 import com.flytrap.rssreader.api.post.domain.PostId;
-import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
 import com.flytrap.rssreader.api.post.infrastructure.output.PostSummaryOutput;
 import com.flytrap.rssreader.api.post.infrastructure.repository.BookmarkJpaRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostDslRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostJpaRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostOpenJpaRepository;
-import com.flytrap.rssreader.api.subscribe.domain.RssSource;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
-import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
-import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -35,20 +32,20 @@ public class PostQuery {
     private final RssResourceJpaRepository rssResourceJpaRepository;
 
     @Transactional(readOnly = true)
-    public Post read(PostId postId, AccountId accountId) {
+    public Optional<Post> read(PostId postId, AccountId accountId) {
 
-        PostEntity postEntity = postJpaRepository.findById(postId.value())
-            .orElseThrow(() -> new NoSuchDomainException(Post.class));
-        RssSourceEntity rssSourceEntity = rssResourceJpaRepository.findById(
-                postEntity.getId())
-            .orElseThrow(() -> new NoSuchDomainException(RssSource.class));
-        boolean isRead = postOpenJpaRepository.existsByAccountIdAndPostId(
-            accountId.value(), postId.value());
-        boolean isBookmark = bookmarkJpaRepository.existsByAccountIdAndPostId(
-            accountId.value(), postId.value());
+        return postJpaRepository.findById(postId.value())
+            .flatMap(postEntity -> rssResourceJpaRepository.findById(postEntity.getId())
+                .map(rssSourceEntity -> {
+                    boolean isRead = postOpenJpaRepository
+                        .existsByAccountIdAndPostId(accountId.value(), postId.value());
+                    boolean isBookmark = bookmarkJpaRepository
+                        .existsByAccountIdAndPostId(accountId.value(), postId.value());
 
-        return postEntity.toReadOnly(Open.from(isRead), Bookmark.from(isBookmark),
-            rssSourceEntity);
+                    return postEntity.toReadOnly(
+                        Open.from(isRead), Bookmark.from(isBookmark), rssSourceEntity);
+                })
+            );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 
-public interface PostListReadRepository {
+public interface PostDslRepository {
 
     Optional<PostSummaryOutput> findById(Long postId);
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepositoryImpl.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepositoryImpl.java
@@ -23,11 +23,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class PostListReadDslRepository implements PostListReadRepository {
+public class PostDslRepositoryImpl implements PostDslRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public PostListReadDslRepository(EntityManager entityManager) {
+    public PostDslRepositoryImpl(EntityManager entityManager) {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class PostCommandController implements PostCommandControllerApi {
 
-    private static final String DELETE_BOOKMARK_MESSAGE = "북마크가 삭제되었습니다. postId = ";
-
     private final PostCommandService postCommandService;
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -49,16 +47,16 @@ public class PostCommandController implements PostCommandControllerApi {
         return new ApplicationResponse<>(new BookmarkResponse(accountCredentials.id().value(), postId));
     }
 
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/posts/{postId}/bookmarks")
-    public ApplicationResponse<String> unmarkAsBookmark(
+    public ApplicationResponse<Void> unmarkAsBookmark(
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
     ) {
         postCommandService
             .unmarkAsBookmark(new AccountId(accountCredentials.id().value()), new PostId(postId));
 
-        return new ApplicationResponse<>(DELETE_BOOKMARK_MESSAGE + postId);
+        return new ApplicationResponse<>(null);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
@@ -13,19 +13,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class PostCommandController implements PostCommandControllerApi {
 
     private final PostCommandService postCommandService;
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("posts/{postId}/read")
+    @DeleteMapping("/api/posts/{postId}/read")
     public ApplicationResponse<Void> unmarkAsOpened(
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
@@ -36,7 +34,7 @@ public class PostCommandController implements PostCommandControllerApi {
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/posts/{postId}/bookmarks")
+    @PostMapping("/api/posts/{postId}/bookmarks")
     public ApplicationResponse<BookmarkResponse> markAsBookmark(
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
@@ -48,7 +46,7 @@ public class PostCommandController implements PostCommandControllerApi {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/posts/{postId}/bookmarks")
+    @DeleteMapping("/api/posts/{postId}/bookmarks")
     public ApplicationResponse<Void> unmarkAsBookmark(
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
@@ -2,9 +2,9 @@ package com.flytrap.rssreader.api.post.presentation.controller;
 
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
-import com.flytrap.rssreader.api.post.business.service.PostUpdateService;
+import com.flytrap.rssreader.api.post.business.service.PostCommandService;
 import com.flytrap.rssreader.api.post.domain.PostId;
-import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostUpdateControllerApi;
+import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostCommandControllerApi;
 import com.flytrap.rssreader.api.post.presentation.dto.response.BookmarkResponse;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.global.presentation.resolver.Login;
@@ -20,11 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class PostUpdateController implements PostUpdateControllerApi {
+public class PostCommandController implements PostCommandControllerApi {
 
     private static final String DELETE_BOOKMARK_MESSAGE = "북마크가 삭제되었습니다. postId = ";
 
-    private final PostUpdateService postUpdateService;
+    private final PostCommandService postCommandService;
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("posts/{postId}/read")
@@ -32,7 +32,7 @@ public class PostUpdateController implements PostUpdateControllerApi {
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
     ) {
-        postUpdateService.unmarkAsOpen(new AccountId(accountCredentials.id().value()), new PostId(postId));
+        postCommandService.unmarkAsOpen(new AccountId(accountCredentials.id().value()), new PostId(postId));
 
         return new ApplicationResponse<>(null);
     }
@@ -43,7 +43,7 @@ public class PostUpdateController implements PostUpdateControllerApi {
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
     ) {
-        postUpdateService
+        postCommandService
             .markAsBookmark(new AccountId(accountCredentials.id().value()), new PostId(postId));
 
         return new ApplicationResponse<>(new BookmarkResponse(accountCredentials.id().value(), postId));
@@ -55,7 +55,7 @@ public class PostUpdateController implements PostUpdateControllerApi {
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials
     ) {
-        postUpdateService
+        postCommandService
             .unmarkAsBookmark(new AccountId(accountCredentials.id().value()), new PostId(postId));
 
         return new ApplicationResponse<>(DELETE_BOOKMARK_MESSAGE + postId);

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListQueryController.java
@@ -3,9 +3,9 @@ package com.flytrap.rssreader.api.post.presentation.controller;
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
 import com.flytrap.rssreader.api.folder.domain.FolderId;
-import com.flytrap.rssreader.api.post.business.service.PostListReadService;
+import com.flytrap.rssreader.api.post.business.service.PostListQueryService;
 import com.flytrap.rssreader.api.post.domain.PostFilter;
-import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostListReadControllerApi;
+import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostListQueryControllerApi;
 import com.flytrap.rssreader.api.post.presentation.dto.response.PostResponse;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
@@ -22,9 +22,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class PostListReadController implements PostListReadControllerApi {
+public class PostListQueryController implements PostListQueryControllerApi {
 
-    private final PostListReadService postListReadService;
+    private final PostListQueryService postListQueryService;
 
     @GetMapping("/posts")
     public ApplicationResponse<PostResponse.PostListResponse> getPostsByAccount(
@@ -32,7 +32,7 @@ public class PostListReadController implements PostListReadControllerApi {
         @PageableDefault(page = 0, size = 15) Pageable pageable,
         @Login AccountCredentials accountCredentials) {
 
-        List<PostResponse> posts = postListReadService.getPostsByAccount(
+        List<PostResponse> posts = postListQueryService.getPostsByAccount(
                 new AccountId(accountCredentials.id().value()), postFilter, pageable)
             .stream()
             .map(PostResponse::from)
@@ -49,7 +49,7 @@ public class PostListReadController implements PostListReadControllerApi {
         @PageableDefault(page = 0, size = 15) Pageable pageable,
         @Login AccountCredentials accountCredentials) {
 
-        List<PostResponse> posts = postListReadService.getPostsByFolder(
+        List<PostResponse> posts = postListQueryService.getPostsByFolder(
                 new AccountId(accountCredentials.id().value()), new FolderId(folderId), postFilter, pageable)
             .stream()
             .map(PostResponse::from)
@@ -67,7 +67,7 @@ public class PostListReadController implements PostListReadControllerApi {
         // TODO: pageable 도 마찬가지. service 에서 만들면 됨
         @Login AccountCredentials accountCredentials) {
 
-        List<PostResponse> posts = postListReadService.getPostsBySubscription(
+        List<PostResponse> posts = postListQueryService.getPostsBySubscription(
                 new AccountId(accountCredentials.id().value()), new SubscriptionId(subscriptionId),
                 postFilter, pageable)
             .stream()
@@ -85,7 +85,7 @@ public class PostListReadController implements PostListReadControllerApi {
         @Login AccountCredentials accountCredentials
     ) {
 
-        List<PostResponse> posts = postListReadService.getBookmarkedPosts(
+        List<PostResponse> posts = postListQueryService.getBookmarkedPosts(
                 new AccountId(accountCredentials.id().value()), postFilter, pageable)
             .stream()
             .map(PostResponse::from)

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostListQueryController.java
@@ -16,17 +16,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class PostListQueryController implements PostListQueryControllerApi {
 
     private final PostListQueryService postListQueryService;
 
-    @GetMapping("/posts")
+    @GetMapping("/api/posts")
     public ApplicationResponse<PostResponse.PostListResponse> getPostsByAccount(
         PostFilter postFilter, // TODO: filter 가 request 부터 repository까지 계속 전달됨
         @PageableDefault(page = 0, size = 15) Pageable pageable,
@@ -42,7 +40,7 @@ public class PostListQueryController implements PostListQueryControllerApi {
             new PostResponse.PostListResponse(posts));
     }
 
-    @GetMapping("/folders/{folderId}/posts")
+    @GetMapping("/api/folders/{folderId}/posts")
     public ApplicationResponse<PostResponse.PostListResponse> getPostsByFolder(
         @PathVariable Long folderId,
         PostFilter postFilter, // TODO: filter 가 request 부터 repository까지 계속 전달됨
@@ -59,7 +57,7 @@ public class PostListQueryController implements PostListQueryControllerApi {
             new PostResponse.PostListResponse(posts));
     }
 
-    @GetMapping("/subscriptions/{subscriptionId}/posts")
+    @GetMapping("/api/subscriptions/{subscriptionId}/posts")
     public ApplicationResponse<PostResponse.PostListResponse> getPostsBySubscription(
         @PathVariable Long subscriptionId,
         PostFilter postFilter, // TODO: filter 가 request 부터 repository까지 계속 전달됨
@@ -78,7 +76,7 @@ public class PostListQueryController implements PostListQueryControllerApi {
             new PostResponse.PostListResponse(posts));
     }
 
-    @GetMapping("/bookmarks")
+    @GetMapping("/api/bookmarks")
     public ApplicationResponse<PostResponse.PostListResponse> getBookmarkedPosts(
         PostFilter postFilter,
         @PageableDefault(page = 0, size = 15) Pageable pageable,

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
@@ -2,9 +2,9 @@ package com.flytrap.rssreader.api.post.presentation.controller;
 
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
-import com.flytrap.rssreader.api.post.business.service.PostReadService;
+import com.flytrap.rssreader.api.post.business.service.PostQueryService;
 import com.flytrap.rssreader.api.post.domain.PostId;
-import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostReadControllerApi;
+import com.flytrap.rssreader.api.post.presentation.controller.swagger.PostQueryControllerApi;
 import com.flytrap.rssreader.api.post.presentation.dto.response.PostResponse;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
 import com.flytrap.rssreader.global.presentation.resolver.Login;
@@ -17,9 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
-public class PostReadController implements PostReadControllerApi {
+public class PostQueryController implements PostQueryControllerApi {
 
-    private final PostReadService postReadService;
+    private final PostQueryService postQueryService;
 
     @GetMapping("/{postId}")
     public ApplicationResponse<PostResponse> getPost(
@@ -27,7 +27,7 @@ public class PostReadController implements PostReadControllerApi {
         @Login AccountCredentials accountCredentials) {
 
         PostResponse response = PostResponse.from(
-            postReadService.viewPost(new AccountId(accountCredentials.id().value()), new PostId(postId)));
+            postQueryService.viewPost(new AccountId(accountCredentials.id().value()), new PostId(postId)));
         return new ApplicationResponse<>(response);
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
@@ -11,17 +11,15 @@ import com.flytrap.rssreader.global.presentation.resolver.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/posts")
 @RequiredArgsConstructor
 public class PostQueryController implements PostQueryControllerApi {
 
     private final PostQueryService postQueryService;
 
-    @GetMapping("/{postId}")
+    @GetMapping("/api/posts/{postId}")
     public ApplicationResponse<PostResponse> getPost(
         @PathVariable Long postId,
         @Login AccountCredentials accountCredentials) {

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.PathVariable;
 
-public interface PostUpdateControllerApi {
+public interface PostCommandControllerApi {
 
     @Operation(summary = "북마크 추가", description = "게시글 하나를 북마크에 추가한다.")
     @ApiResponses(value = {

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
@@ -27,7 +27,7 @@ public interface PostCommandControllerApi {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
     })
-    ApplicationResponse<String> unmarkAsBookmark(
+    ApplicationResponse<Void> unmarkAsBookmark(
         @Parameter(description = "북마크를 제거할 게시글 ID") @PathVariable Long postId,
         @Parameter(description = "현재 로그인한 회원 정보") @Login AccountCredentials member
     );

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostListQueryControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostListQueryControllerApi.java
@@ -17,7 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "게시글 목록 불러오기")
-public interface PostListReadControllerApi {
+public interface PostListQueryControllerApi {
 
     @Operation(summary = "전체 게시글 목록 불러오기", description = "회원이 구독한 모든 블로그의 게시글 목록을 반환한다.")
     @ApiResponses(value = {

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostQueryControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostQueryControllerApi.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag("Posts")
-public interface PostReadControllerApi {
+public interface PostQueryControllerApi {
 
     @Operation(summary = "게시글 불러오기", description = "게시글 하나를 불러온다.")
     @ApiResponses(value = {

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/PostResponse.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/PostResponse.java
@@ -18,7 +18,6 @@ public record PostResponse(
 
     public record PostListResponse(
             List<PostResponse> posts
-            // TODO: react
     ) { }
 
     public static PostResponse from(Post post) {

--- a/src/test/java/com/flytrap/rssreader/api/post/PostScriptSql.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/PostScriptSql.java
@@ -1,0 +1,16 @@
+package com.flytrap.rssreader.api.post;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Sql(scripts = "/reset.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/db/post-sample.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public @interface PostScriptSql {
+
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostCommandServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostCommandServiceTest.java
@@ -1,0 +1,127 @@
+package com.flytrap.rssreader.api.post.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.flytrap.rssreader.CustomServiceTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.post.PostScriptSql;
+import com.flytrap.rssreader.api.post.domain.Bookmark;
+import com.flytrap.rssreader.api.post.domain.Open;
+import com.flytrap.rssreader.api.post.domain.PostId;
+import com.flytrap.rssreader.api.post.infrastructure.implementation.PostQuery;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@CustomServiceTest
+class PostCommandServiceTest {
+
+    @Autowired
+    PostCommandService postCommandService;
+
+    @Autowired
+    PostQuery postQuery;
+
+    @Nested
+    @PostScriptSql
+    class UnmarkAsOpen {
+
+        @Test
+        void 게시글_읽음_상태를_취소할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(1L);
+
+            // when
+            postCommandService.unmarkAsOpen(accountId, postId);
+            var unOpenedPost = postQuery.read(postId, accountId).get();
+
+            // then
+            assertThat(unOpenedPost.getOpen()).isEqualTo(Open.UNMARKED);
+        }
+
+        @Test
+        void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(999L);
+
+            // when
+            Executable postExecutable = () ->
+                postCommandService.unmarkAsOpen(accountId, postId);
+
+            // then
+            assertThrows(NoSuchDomainException.class, postExecutable);
+        }
+
+    }
+
+    @Nested
+    @PostScriptSql
+    class MarkAsBookmark {
+
+        @Test
+        void 북마크를_추가할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(1L);
+
+            // when
+            postCommandService.markAsBookmark(accountId, postId);
+            var bookmarkedPost = postQuery.read(postId, accountId).get();
+
+            // then
+            assertThat(bookmarkedPost.getBookmark()).isEqualTo(Bookmark.MARKED);
+        }
+
+        @Test
+        void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(999L);
+
+            // when
+            Executable postExecutable = () ->
+                postCommandService.markAsBookmark(accountId, postId);
+
+            // then
+            assertThrows(NoSuchDomainException.class, postExecutable);
+        }
+    }
+
+    @Nested
+    @PostScriptSql
+    class UnmarkAsBookmark {
+
+        @Test
+        void 북마크를_취소할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(1L);
+
+            // when
+            postCommandService.unmarkAsBookmark(accountId, postId);
+            var bookmarkedPost = postQuery.read(postId, accountId).get();
+
+            // then
+            assertThat(bookmarkedPost.getBookmark()).isEqualTo(Bookmark.UNMARKED);
+        }
+
+        @Test
+        void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(999L);
+
+            // when
+            Executable postExecutable = () ->
+                postCommandService.unmarkAsBookmark(accountId, postId);
+
+            // then
+            assertThrows(NoSuchDomainException.class, postExecutable);
+        }
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostListQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostListQueryServiceTest.java
@@ -1,0 +1,127 @@
+package com.flytrap.rssreader.api.post.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.flytrap.rssreader.CustomServiceTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.folder.domain.FolderId;
+import com.flytrap.rssreader.api.post.PostScriptSql;
+import com.flytrap.rssreader.api.post.domain.Bookmark;
+import com.flytrap.rssreader.api.post.domain.PostAggregate;
+import com.flytrap.rssreader.api.post.domain.PostFilter;
+import com.flytrap.rssreader.api.post.domain.PostId;
+import com.flytrap.rssreader.api.post.infrastructure.implementation.PostCommand;
+import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+
+
+@CustomServiceTest
+class PostListQueryServiceTest {
+
+    @Autowired
+    PostListQueryService postListQueryService;
+
+    @Autowired
+    PostCommand postCommand;
+
+    @Nested
+    @PostScriptSql
+    class getPostsByAccount {
+
+        @Test
+        void 회원이_볼수있는_모든_게시글을_조회할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postFilter = new PostFilter(null, null, null, null);
+            var pageable = Pageable.ofSize(15);
+
+            // when
+            var posts = postListQueryService
+                .getPostsByAccount(accountId, postFilter, pageable);
+
+            // then
+            assertThat(posts).hasSize(8);
+        }
+
+    }
+
+    @Nested
+    @PostScriptSql
+    class getPostsByFolder {
+
+        @Test
+        void 폴더별_게시글을_조회할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var folderId = new FolderId(1L);
+            var postFilter = new PostFilter(null, null, null, null);
+            var pageable = Pageable.ofSize(15);
+
+            // when
+            var posts = postListQueryService
+                .getPostsByFolder(accountId, folderId, postFilter, pageable);
+
+            // then
+            assertThat(posts).hasSize(4);
+        }
+    }
+
+    @Nested
+    @PostScriptSql
+    class getPostsBySubscription {
+
+        @Test
+        void 구독물별_게시글을_조회할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var subscriptionId = new SubscriptionId(1L);
+            var postFilter = new PostFilter(null, null, null, null);
+            var pageable = Pageable.ofSize(15);
+
+            // when
+            var posts = postListQueryService
+                .getPostsBySubscription(accountId, subscriptionId, postFilter, pageable);
+
+            // then
+            assertThat(posts).hasSize(2);
+        }
+    }
+
+    @Nested
+    @PostScriptSql
+    class getBookmarkedPosts {
+
+        @Test
+        void 북마크된_게시글을_조회할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postFilter = new PostFilter(null, null, null, null);
+            var pageable = Pageable.ofSize(15);
+
+            postCommand.updateOnlyBookmark(
+                PostAggregate.builder()
+                    .id(new PostId(1L))
+                    .bookmark(Bookmark.MARKED).build(),
+                accountId
+            );
+
+            postCommand.updateOnlyBookmark(
+                PostAggregate.builder()
+                    .id(new PostId(2L))
+                    .bookmark(Bookmark.MARKED).build(),
+                accountId
+            );
+
+            // when
+            var posts = postListQueryService
+                .getBookmarkedPosts(accountId, postFilter, pageable);
+
+            // then
+            assertThat(posts).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostQueryServiceTest.java
@@ -1,0 +1,58 @@
+package com.flytrap.rssreader.api.post.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.flytrap.rssreader.CustomServiceTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.post.PostScriptSql;
+import com.flytrap.rssreader.api.post.domain.PostId;
+import com.flytrap.rssreader.api.post.infrastructure.implementation.PostQuery;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@CustomServiceTest
+class PostQueryServiceTest {
+
+    @Autowired
+    PostQueryService postQueryService;
+
+    @Autowired
+    PostQuery postQuery;
+
+    @Nested
+    @PostScriptSql
+    class ViewPost {
+
+        @Test
+        void 게시글_정보를_불러올_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(1L);
+
+            // when
+            var result = postQueryService.viewPost(accountId, postId);
+
+            //then
+            assertThat(result.getId()).isEqualTo(postId);
+        }
+
+        @Test
+        void 존재하지_않는_게시글을_불러오면_예외가_발생한다() {
+            // given
+            var accountId = new AccountId(1L);
+            var postId = new PostId(999L);
+
+            // when
+            Executable viewPostExecutable = ()
+                -> postQueryService.viewPost(accountId, postId);
+
+            //then
+            assertThrows(NoSuchDomainException.class, viewPostExecutable);
+        }
+
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandControllerTest.java
@@ -1,0 +1,151 @@
+package com.flytrap.rssreader.api.post.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flytrap.rssreader.CustomControllerTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.account.domain.AccountRoll;
+import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.api.post.PostScriptSql;
+import com.flytrap.rssreader.api.post.domain.Bookmark;
+import com.flytrap.rssreader.api.post.domain.Open;
+import com.flytrap.rssreader.api.post.domain.PostAggregate;
+import com.flytrap.rssreader.api.post.domain.PostId;
+import com.flytrap.rssreader.api.post.infrastructure.implementation.PostCommand;
+import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
+import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
+import javax.security.sasl.AuthenticationException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomControllerTest
+class PostCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthorizationArgumentResolver authorizationArgumentResolver;
+
+    @MockBean
+    AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
+
+    @Autowired
+    PostCommand postCommand;
+
+    @Nested
+    @PostScriptSql
+    class 게시글_읽음_상태_취소_API {
+
+        @Test
+        void 읽음_상태_취소_성공시_204응답을_반환한다() throws Exception {
+            // given
+            postCommand.updateOnlyOpen(
+                PostAggregate.builder().id(new PostId(1L)).open(Open.MARKED).build(),
+                new AccountId(1L)
+            );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            mockMvc.perform(delete("/api/posts/{postId}/read", 1))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            // when, then
+            mockMvc.perform(delete("/api/posts/{postId}/read", 1))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @PostScriptSql
+    class 게시글_북마크_추가_API {
+
+        @Test
+        void 북마크_추가_성공시_201응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            mockMvc.perform(post("/api/posts/{postId}/bookmarks", 1))
+                .andExpect(status().isCreated());
+        }
+
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            // when, then
+            mockMvc.perform(post("/api/posts/{postId}/bookmarks", 1))
+                .andExpect(status().isUnauthorized());
+        }
+
+    }
+
+    @Nested
+    @PostScriptSql
+    class 게시글_북마크_취소_API {
+
+        @Test
+        void 북마크_취소_성공시_204응답을_반환한다() throws Exception {
+            // given
+            postCommand.updateOnlyBookmark(
+                PostAggregate.builder().id(new PostId(1L)).bookmark(Bookmark.MARKED).build(),
+                new AccountId(1L)
+            );
+
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", 1))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            // when, then
+            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", 1))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
@@ -1,0 +1,78 @@
+package com.flytrap.rssreader.api.post.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.flytrap.rssreader.CustomControllerTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.account.domain.AccountRoll;
+import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
+import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
+import javax.security.sasl.AuthenticationException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomControllerTest
+class PostQueryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    AuthorizationArgumentResolver authorizationArgumentResolver;
+
+    @MockBean
+    AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
+
+    @Nested
+    @Sql(scripts = "/post-sample.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    class 게시글_보기_API {
+
+        @Test
+        void 게시글_보기_요청이_성공하면_200응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+
+            // when, then
+            mockMvc.perform(get("/api/posts/{postId}", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").hasJsonPath())
+                .andExpect(jsonPath("$.data.guid").hasJsonPath())
+                .andExpect(jsonPath("$.data.title").hasJsonPath())
+                .andExpect(jsonPath("$.data.thumbnailUrl").hasJsonPath())
+                .andExpect(jsonPath("$.data.description").hasJsonPath())
+                .andExpect(jsonPath("$.data.pubDate").hasJsonPath())
+                .andExpect(jsonPath("$.data.subscribeTitle").hasJsonPath())
+                .andExpect(jsonPath("$.data.open").hasJsonPath())
+                .andExpect(jsonPath("$.data.bookmark").hasJsonPath());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            // when, then
+            mockMvc.perform(get("/api/posts/{postId}", 1))
+                .andExpect(status().isUnauthorized());
+        }
+
+    }
+
+}

--- a/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
@@ -10,6 +10,7 @@ import com.flytrap.rssreader.CustomControllerTest;
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.account.domain.AccountRoll;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.api.post.PostScriptSql;
 import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
 import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
 import javax.security.sasl.AuthenticationException;
@@ -17,8 +18,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.web.servlet.MockMvc;
 
 @CustomControllerTest
@@ -34,7 +33,7 @@ class PostQueryControllerTest {
     AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
 
     @Nested
-    @Sql(scripts = "/post-sample.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    @PostScriptSql
     class 게시글_보기_API {
 
         @Test

--- a/src/test/resources/db/post-sample.sql
+++ b/src/test/resources/db/post-sample.sql
@@ -15,3 +15,15 @@ VALUES
     (2, 'title02', 'url02', 'TISTORY', '2024-01-01 00:00:00.000000'),
     (3, 'title03', 'url03', 'MEDIUM', '2024-01-01 00:00:00.000000'),
     (4, 'title04', 'url04', 'ETC', '2024-01-01 00:00:00.000000');
+
+INSERT INTO `folder`(id, account_id, name, is_shared, is_deleted)
+VALUES
+    (1, 1, 'folder 1', false, false),
+    (2, 1, 'folder 2', false, false);
+
+INSERT INTO `subscription`(id, folder_id, rss_source_id)
+VALUES
+    (1, 1, 1),
+    (2, 1, 2),
+    (3, 2, 3),
+    (4, 2, 4);

--- a/src/test/resources/post-sample.sql
+++ b/src/test/resources/post-sample.sql
@@ -1,0 +1,17 @@
+INSERT INTO `post`(id, guid, title, thumbnail_url, description, pub_date, rss_source_id)
+VALUES
+    (1, 'guid01', 'title01', 'url01', 'description01', '2024-01-01 00:00:00.000000', 1),
+    (2, 'guid02', 'title02', 'url02', 'description02', '2024-01-01 00:00:00.000000', 1),
+    (3, 'guid03', 'title03', 'url03', 'description03', '2024-01-01 00:00:00.000000', 2),
+    (4, 'guid04', 'title04', 'url04', 'description04', '2024-01-01 00:00:00.000000', 2),
+    (5, 'guid05', 'title05', 'url05', 'description05', '2024-01-01 00:00:00.000000', 3),
+    (6, 'guid06', 'title06', 'url06', 'description06', '2024-01-01 00:00:00.000000', 3),
+    (7, 'guid07', 'title07', 'url07', 'description07', '2024-01-01 00:00:00.000000', 4),
+    (8, 'guid08', 'title08', 'url08', 'description08', '2024-01-01 00:00:00.000000', 4);
+
+INSERT INTO `rss_source`(id, title, url, platform, last_collected_at)
+VALUES
+    (1, 'title01', 'url01', 'VELOG', '2024-01-01 00:00:00.000000'),
+    (2, 'title02', 'url02', 'TISTORY', '2024-01-01 00:00:00.000000'),
+    (3, 'title03', 'url03', 'MEDIUM', '2024-01-01 00:00:00.000000'),
+    (4, 'title04', 'url04', 'ETC', '2024-01-01 00:00:00.000000');


### PR DESCRIPTION
# 🔑 Key Changes
- Post 2차 리펙토링 및 테스트 추가

# 👩‍💻 To Reviewers
## PostQueryControllerTest 테스트 케이스
### 게시글 보기 API
- 게시글 보기 요청이 성공하면 200응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다

## PostCommandControllerTest 테스트 케이스
### 게시글 읽음 상태 취소 API
- 읽음 상태 취소 성공시 204응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다

### 게시글 북마크 추가 API
- 북마크 추가 성공시 201응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다

### 게시글 북마크 취소 API
- 북마크 취소 성공시 204응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다

## PostQueryServiceTest 테스트 케이스
- 게시글 정보를 불러올 수 있다
- 존재하지 않는 게시글을 불러오면 예외가 발생한다

## PostListQueryServiceTest 테스트 케이스
- 회원이 볼수있는 모든 게시글을 조회할 수 있다
- 폴더별 게시글을 조회할 수 있다
- 구독물별 게시글을 조회할 수 있다
- 북마크된 게시글을 조회할 수 있다

## PostCommandServiceTest 테스트 케이스
### UnmarkAsOpen
- 게시글 읽음 상태를 취소할 수 있다
- 존재하지 않는 게시글을 조작할 경우 예외를 던진다

### MarkAsBookmark
- 북마크를 추가할 수 있다
- 존재하지 않는 게시글을 조작할 경우 예외를 던진다

### UnmarkAsBookmark
- 북마크를 취소할 수 있다
- 존재하지 않는 게시글을 조작할 경우 예외를 던진다

# Related to
- #258 
