### PR TITLE
Subscription 2차 리팩토링 및 테스트 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostListQueryService.java
@@ -11,6 +11,7 @@ import com.flytrap.rssreader.api.subscribe.domain.Subscription;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.implement.SubscriptionQuery;
 import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
+import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -43,7 +44,8 @@ public class PostListQueryService {
 
     public List<Post> getPostsBySubscription(AccountId accountId, SubscriptionId subscriptionId,
         PostFilter postFilter, Pageable pageable) {
-        Subscription subscription = subscriptionQuery.read(subscriptionId);
+        Subscription subscription = subscriptionQuery.read(subscriptionId)
+            .orElseThrow(() -> new NoSuchDomainException(Subscription.class));
 
         return postQuery.readAllBySubscription(accountId, subscription.getRssSourceId(), postFilter, pageable);
     }

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostQueryService.java
@@ -25,7 +25,8 @@ public class PostQueryService {
 
         PostAggregate postAggregate = postCommand.readAggregate(postId, accountId)
             .orElseThrow(() -> new NoSuchDomainException(PostAggregate.class));
-        RssSource rssSource = rssSourceQuery.read(postAggregate.getRssSourceId());
+        RssSource rssSource = rssSourceQuery.read(postAggregate.getRssSourceId())
+            .orElseThrow(() -> new NoSuchDomainException(RssSource.class));
 
         globalEventPublisher.publish(new PostOpenEvent(postAggregate, accountId));
 

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/business/service/SubscriptionCommandService.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/business/service/SubscriptionCommandService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SubscriptionService {
+public class SubscriptionCommandService {
 
     private final FolderValidator folderValidator;
     private final SubscriptionValidator subscriptionValidator;

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/RssSourceQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/RssSourceQuery.java
@@ -2,8 +2,9 @@ package com.flytrap.rssreader.api.subscribe.infrastructure.implement;
 
 import com.flytrap.rssreader.api.subscribe.domain.RssSource;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
+import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
-import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,10 +14,9 @@ public class RssSourceQuery {
 
     private final RssResourceJpaRepository rssResourceJpaRepository;
 
-    public RssSource read(RssSourceId rssSourceId) {
+    public Optional<RssSource> read(RssSourceId rssSourceId) {
         return rssResourceJpaRepository.findById(rssSourceId.value())
-            .orElseThrow(() -> new NoSuchDomainException(RssSource.class))
-            .toExistingRssSource();
+            .map(RssSourceEntity::toExistingRssSource);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionQuery.java
@@ -5,8 +5,8 @@ import com.flytrap.rssreader.api.subscribe.domain.Subscription;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.output.SubscriptionOutput;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.SubscriptionDslRepository;
-import com.flytrap.rssreader.global.exception.domain.NoSuchDomainException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,11 +16,10 @@ public class SubscriptionQuery {
 
     private final SubscriptionDslRepository subscriptionDslRepository;
 
-    public Subscription read(SubscriptionId subscriptionId) {
+    public Optional<Subscription> read(SubscriptionId subscriptionId) {
         return subscriptionDslRepository
             .findById(subscriptionId.value())
-            .orElseThrow(() -> new NoSuchDomainException(Subscription.class))
-            .toReadOnly();
+            .map(SubscriptionOutput::toReadOnly);
     }
 
     public List<Subscription> readAllByFolder(FolderId folderId) {

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandCommandController.java
@@ -2,10 +2,10 @@ package com.flytrap.rssreader.api.subscribe.presentation.controller;
 
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
 import com.flytrap.rssreader.api.folder.domain.FolderId;
-import com.flytrap.rssreader.api.subscribe.business.service.SubscriptionService;
+import com.flytrap.rssreader.api.subscribe.business.service.SubscriptionCommandService;
 import com.flytrap.rssreader.api.subscribe.domain.Subscription;
 import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
-import com.flytrap.rssreader.api.subscribe.presentation.controller.swagger.SubscriptionControllerApi;
+import com.flytrap.rssreader.api.subscribe.presentation.controller.swagger.SubscriptionCommandControllerApi;
 import com.flytrap.rssreader.api.subscribe.presentation.dto.AddSubscriptionRequest;
 import com.flytrap.rssreader.api.subscribe.presentation.dto.SubscriptionResponse;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
@@ -22,9 +22,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class SubscriptionController implements SubscriptionControllerApi {
+public class SubscriptionCommandCommandController implements SubscriptionCommandControllerApi {
 
-    private final SubscriptionService subscriptionService;
+    private final SubscriptionCommandService subscriptionCommandService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/folders/{folderId}/subscriptions")
@@ -33,7 +33,7 @@ public class SubscriptionController implements SubscriptionControllerApi {
         @Valid @RequestBody AddSubscriptionRequest request,
         @Login AccountCredentials accountCredentials
     ) {
-        Subscription subscription = subscriptionService
+        Subscription subscription = subscriptionCommandService
             .addSubscriptionToFolder(
                 accountCredentials.id(),
                 new FolderId(folderId),
@@ -50,7 +50,7 @@ public class SubscriptionController implements SubscriptionControllerApi {
         @PathVariable Long subscriptionId,
         @Login AccountCredentials accountCredentials
     ) {
-        subscriptionService.removeSubscriptionToFolder(
+        subscriptionCommandService.removeSubscriptionToFolder(
             accountCredentials.id(),
             new FolderId(folderId),
             new SubscriptionId(subscriptionId)

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class SubscriptionCommandCommandController implements SubscriptionCommandControllerApi {
+public class SubscriptionCommandController implements SubscriptionCommandControllerApi {
 
     private final SubscriptionCommandService subscriptionCommandService;
 
@@ -44,7 +44,7 @@ public class SubscriptionCommandCommandController implements SubscriptionCommand
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/api/folders/{folderId}/subscriptions/{subscriptionId}") // TODO: url에서 rss 부분 수정하기 + 프론트
+    @DeleteMapping("/api/folders/{folderId}/subscriptions/{subscriptionId}")
     public ApplicationResponse<Void> removeSubscriptionToFolder(
         @PathVariable Long folderId,
         @PathVariable Long subscriptionId,

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/swagger/SubscriptionCommandControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/presentation/controller/swagger/SubscriptionCommandControllerApi.java
@@ -15,7 +15,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-public interface SubscriptionControllerApi {
+public interface SubscriptionCommandControllerApi {
 
     @Operation(summary = "폴더에 구독 추가하기", description = "이미 추가된 폴더에 구독을 새로 추가한다.")
     @ApiResponses(value = {

--- a/src/test/java/com/flytrap/rssreader/api/subscribe/business/service/SubscriptionCommandServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/subscribe/business/service/SubscriptionCommandServiceTest.java
@@ -1,0 +1,170 @@
+package com.flytrap.rssreader.api.subscribe.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.flytrap.rssreader.CustomServiceTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.folder.domain.FolderCreate;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderQuery;
+import com.flytrap.rssreader.api.parser.RssSubscribeParser;
+import com.flytrap.rssreader.api.parser.dto.RssSourceData;
+import com.flytrap.rssreader.api.subscribe.domain.BlogPlatform;
+import com.flytrap.rssreader.api.subscribe.infrastructure.implement.SubscriptionCommand;
+import com.flytrap.rssreader.global.exception.domain.DuplicateDomainException;
+import com.flytrap.rssreader.global.exception.domain.ForbiddenAccessFolderException;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@CustomServiceTest
+class SubscriptionCommandServiceTest {
+
+    @Autowired
+    SubscriptionCommandService subscriptionCommandService;
+
+    @Autowired
+    FolderCommand folderCommand;
+
+    @Autowired
+    SubscriptionCommand subscriptionCommand;
+
+    @Autowired
+    FolderQuery folderQuery;
+
+    @MockBean
+    RssSubscribeParser rssSubscribeParser;
+
+    @Nested
+    class AddSubscriptionToFolder {
+
+        @Test
+        void 폴더에_구독을_추가할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var rssUrl = "URL";
+            var myFolder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(accountId)
+                    .build()
+            );
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            // when
+            var subscription = subscriptionCommandService
+                .addSubscriptionToFolder(accountId, myFolder.getId(), rssUrl);
+
+            // then
+            assertThat(subscription.getId()).isNotNull();
+        }
+
+        @Test
+        void 접근_불가능한_폴더에_구독을_추가할_수_없다() {
+            // given
+            var accountId = new AccountId(1L);
+            var rssUrl = "URL";
+            var myFolder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(999L))
+                    .build()
+            );
+
+            // when
+            Executable subscriptionExecutable = () -> subscriptionCommandService
+                .addSubscriptionToFolder(accountId, myFolder.getId(), rssUrl);
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, subscriptionExecutable);
+        }
+
+        @Test
+        void 한_폴더에_구독을_중복으로_추가할_수_없다() {
+            // given
+            var accountId = new AccountId(1L);
+            var rssUrl = "URL";
+            var myFolder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(accountId)
+                    .build()
+            );
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+            var mySubscription = subscriptionCommand
+                .createFrom(myFolder.getId(), rssUrl);
+
+            // when
+            Executable subscriptionExecutable = () -> subscriptionCommandService
+                .addSubscriptionToFolder(accountId, myFolder.getId(), rssUrl);
+
+            // then
+            assertThrows(DuplicateDomainException.class, subscriptionExecutable);
+        }
+    }
+
+    @Nested
+    class RemoveSubscriptionToFolder {
+
+        @Test
+        void 폴더에_추가된_구독을_제거할_수_있다() {
+            // given
+            var accountId = new AccountId(1L);
+            var rssUrl = "URL";
+            var myFolder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(accountId)
+                    .build()
+            );
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+            var mySubscription = subscriptionCommand
+                .createFrom(myFolder.getId(), rssUrl);
+
+            // when
+            subscriptionCommandService
+                .removeSubscriptionToFolder(accountId, myFolder.getId(), mySubscription.getId());
+            var folderResult = folderQuery.read(myFolder.getId()).get();
+
+            // then
+            assertThat(folderResult.getSubscriptions()).hasSize(0);
+        }
+
+        @Test
+        void 접근_불가능한_폴더의_구독은_삭제할_수_없다() {
+            // given
+            var accountId = new AccountId(1L);
+            var rssUrl = "URL";
+            var myFolder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(999L))
+                    .build()
+            );
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+            var mySubscription = subscriptionCommand
+                .createFrom(myFolder.getId(), rssUrl);
+
+            // when
+            Executable subscriptionExecutable = () -> subscriptionCommandService
+                .removeSubscriptionToFolder(accountId, myFolder.getId(), mySubscription.getId());
+
+            // then
+            assertThrows(ForbiddenAccessFolderException.class, subscriptionExecutable);
+        }
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/subscribe/presentation/controller/SubscriptionCommandControllerTest.java
@@ -1,0 +1,257 @@
+package com.flytrap.rssreader.api.subscribe.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flytrap.rssreader.CustomControllerTest;
+import com.flytrap.rssreader.api.account.domain.AccountId;
+import com.flytrap.rssreader.api.account.domain.AccountRoll;
+import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
+import com.flytrap.rssreader.api.folder.domain.FolderCreate;
+import com.flytrap.rssreader.api.folder.infrastructure.implementatioin.FolderCommand;
+import com.flytrap.rssreader.api.parser.RssSubscribeParser;
+import com.flytrap.rssreader.api.parser.dto.RssSourceData;
+import com.flytrap.rssreader.api.subscribe.domain.BlogPlatform;
+import com.flytrap.rssreader.api.subscribe.infrastructure.implement.SubscriptionCommand;
+import com.flytrap.rssreader.api.subscribe.presentation.dto.AddSubscriptionRequest;
+import com.flytrap.rssreader.global.presentation.resolver.AdminAuthorizationArgumentResolver;
+import com.flytrap.rssreader.global.presentation.resolver.AuthorizationArgumentResolver;
+import java.util.Optional;
+import javax.security.sasl.AuthenticationException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomControllerTest
+class SubscriptionCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthorizationArgumentResolver authorizationArgumentResolver;
+
+    @MockBean
+    AdminAuthorizationArgumentResolver adminAuthorizationArgumentResolver;
+
+    @Autowired
+    FolderCommand folderCommand;
+
+    @Autowired
+    SubscriptionCommand subscriptionCommand;
+
+    @MockBean
+    RssSubscribeParser rssSubscribeParser;
+
+    @Nested
+    class 구독_추가하기_API {
+
+        @Test
+        void 구독_추가에_성공하면_201응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(1L))
+                    .build()
+            );
+
+            var request = new AddSubscriptionRequest("URL");
+
+            // when, then
+            mockMvc.perform(post("/api/folders/{folderId}/subscriptions", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.subscribeId").hasJsonPath())
+                .andExpect(jsonPath("$.data.subscribeTitle").hasJsonPath());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+
+            var request = new AddSubscriptionRequest("URL");
+
+            // when, then
+            mockMvc.perform(post("/api/folders/{folderId}/subscriptions", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 폴더에_접근_권한이_없는_경우_403응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(2L))
+                    .build()
+            );
+
+            var request = new AddSubscriptionRequest("URL");
+
+            // when, then
+            mockMvc.perform(post("/api/folders/{folderId}/subscriptions", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void 구독을_중복으로_추가한_경우_400응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(1L))
+                    .build()
+            );
+            var subscription = subscriptionCommand
+                .createFrom(folder.getId(), "URL");
+
+            var request = new AddSubscriptionRequest("URL");
+
+            // when, then
+            mockMvc.perform(post("/api/folders/{folderId}/subscriptions", 1)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+        }
+
+    }
+
+    @Nested
+    class 구독_취소하기_API {
+
+        @Test
+        void 구독_취소에_성공하면_204응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(1L))
+                    .build()
+            );
+            var subscription = subscriptionCommand
+                .createFrom(folder.getId(), "URL");
+
+            // when, then
+            mockMvc.perform(
+                delete("/api/folders/{folderId}/subscriptions/{subscriptionId}",
+                    folder.getId().value(),
+                    subscription.getId().value()))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 로그인_하지_않은_사용자가_요청시_401응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenThrow(AuthenticationException.class);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(1L))
+                    .build()
+            );
+            var subscription = subscriptionCommand
+                .createFrom(folder.getId(), "URL");
+
+            // when, then
+            mockMvc.perform(
+                    delete("/api/folders/{folderId}/subscriptions/{subscriptionId}",
+                        folder.getId().value(),
+                        subscription.getId().value()))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 폴더에_접근_권한이_없는_경우_403응답을_반환한다() throws Exception {
+            // given
+            var accountCredentials = new AccountCredentials(new AccountId(1L), AccountRoll.GENERAL);
+            when(authorizationArgumentResolver.supportsParameter(any()))
+                .thenReturn(true);
+            when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .thenReturn(accountCredentials);
+            when(rssSubscribeParser.parseRssDocuments(any()))
+                .thenReturn(Optional.of(
+                    new RssSourceData("title", "URL", BlogPlatform.VELOG, "description")));
+
+            var folder = folderCommand.create(
+                FolderCreate.builder()
+                    .name("폴더명")
+                    .ownerId(new AccountId(2L))
+                    .build()
+            );
+            var subscription = subscriptionCommand
+                .createFrom(folder.getId(), "URL");
+
+            // when, then
+            mockMvc.perform(
+                    delete("/api/folders/{folderId}/subscriptions/{subscriptionId}",
+                        folder.getId().value(),
+                        subscription.getId().value()))
+                .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
# 🔑 Key Changes
- Subscription 2차 리팩토링 및 테스트 추가

# 👩‍💻 To Reviewers
## SubscriptionCommandControllerTest
### 구독 추가하기 API
- 구독 추가에 성공하면 201응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다
- 폴더에 접근 권한이 없는 경우 403응답을 반환한다
- 구독을 중복으로 추가한 경우 400응답을 반환한다

### 구독 취소하기 API
- 구독 취소에 성공하면 204응답을 반환한다
- 로그인 하지 않은 사용자가 요청시 401응답을 반환한다
- 폴더에 접근 권한이 없는 경우 403응답을 반환한다

## SubscriptionCommandServiceTest
### AddSubscriptionToFolder
- 폴더에 구독을 추가할 수 있다
- 접근 불가능한 폴더에 구독을 추가할 수 없다
- 한 폴더에 구독을 중복으로 추가할 수 없다

### RemoveSubscriptionToFolder
- 폴더에 추가된 구독을 제거할 수 있다
- 접근 불가능한 폴더의 구독은 삭제할 수 없다

# Related to
- #258 
