### PR TITLE
게시글 수집에 멀티 스레드 적용

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/admin/business/service/AdminSystemService.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/business/service/AdminSystemService.java
@@ -48,7 +48,15 @@ public class AdminSystemService {
         adminSystemAggregate.changePostCollectionDelay(delay);
 
         adminSystemCommand.save(adminSystemAggregate);
-        postCollectScheduledService.changePostCollectionDelay(delay);
+        postCollectScheduledService.restartPostCollection();
+    }
+
+    public void changePostCollectionBatchSize(int batchSize) {
+        AdminSystemAggregate adminSystemAggregate = adminSystemCommand.read();
+        adminSystemAggregate.changePostCollectionBatchSize(batchSize);
+
+        adminSystemCommand.save(adminSystemAggregate);
+        postCollectScheduledService.restartPostCollection();
     }
 
     public void changePostCollectionThreadPoolCoreSize(int corePoolSize) {

--- a/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
@@ -12,14 +12,17 @@ public class AdminSystemAggregate implements DefaultDomain {
     private final AdminSystemId id;
     private boolean postCollectionEnabled;
     private long postCollectionDelay;
+    private int coreThreadPoolSize;
 
     @Builder
     protected AdminSystemAggregate(
-        AdminSystemId id, boolean postCollectionEnabled, long postCollectionDelay
+        AdminSystemId id, boolean postCollectionEnabled, long postCollectionDelay,
+        int coreThreadPoolSize
     ) {
         this.id = id;
         this.postCollectionEnabled = postCollectionEnabled;
         this.postCollectionDelay = postCollectionDelay;
+        this.coreThreadPoolSize = coreThreadPoolSize;
     }
 
     public void startPostCollection() {
@@ -32,5 +35,9 @@ public class AdminSystemAggregate implements DefaultDomain {
 
     public void changePostCollectionDelay(long delay) {
         this.postCollectionDelay = delay;
+    }
+
+    public void changeCoreThreadPoolSize(int coreThreadPoolSize) {
+        this.coreThreadPoolSize = coreThreadPoolSize;
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
@@ -12,16 +12,18 @@ public class AdminSystemAggregate implements DefaultDomain {
     private final AdminSystemId id;
     private boolean postCollectionEnabled;
     private long postCollectionDelay;
+    private int postCollectionBatchSize;
     private int coreThreadPoolSize;
 
     @Builder
     protected AdminSystemAggregate(
         AdminSystemId id, boolean postCollectionEnabled, long postCollectionDelay,
-        int coreThreadPoolSize
+        int postCollectionBatchSize, int coreThreadPoolSize
     ) {
         this.id = id;
         this.postCollectionEnabled = postCollectionEnabled;
         this.postCollectionDelay = postCollectionDelay;
+        this.postCollectionBatchSize = postCollectionBatchSize;
         this.coreThreadPoolSize = coreThreadPoolSize;
     }
 
@@ -35,6 +37,10 @@ public class AdminSystemAggregate implements DefaultDomain {
 
     public void changePostCollectionDelay(long delay) {
         this.postCollectionDelay = delay;
+    }
+
+    public void changePostCollectionBatchSize(int postCollectionBatchSize) {
+        this.postCollectionBatchSize = postCollectionBatchSize;
     }
 
     public void changeCoreThreadPoolSize(int coreThreadPoolSize) {

--- a/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/entity/AdminSystemEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/entity/AdminSystemEntity.java
@@ -28,13 +28,18 @@ public class AdminSystemEntity {
     @Column(name = "post_collection_delay")
     private Long postCollectionDelay;
 
+    @Column(name = "core_thread_pool_size")
+    private Integer coreThreadPoolSize;
+
     @Builder
     protected AdminSystemEntity(
-        Long id, boolean postCollectionEnabled, Long postCollectionDelay
+        Long id, boolean postCollectionEnabled, Long postCollectionDelay,
+        Integer coreThreadPoolSize
     ) {
         this.id = id;
         this.postCollectionEnabled = postCollectionEnabled;
         this.postCollectionDelay = postCollectionDelay;
+        this.coreThreadPoolSize = coreThreadPoolSize;
     }
 
     public AdminSystemAggregate toAggregate() {
@@ -42,6 +47,7 @@ public class AdminSystemEntity {
             .id(new AdminSystemId(id))
             .postCollectionEnabled(postCollectionEnabled)
             .postCollectionDelay(postCollectionDelay)
+            .coreThreadPoolSize(coreThreadPoolSize)
             .build();
     }
 
@@ -49,7 +55,8 @@ public class AdminSystemEntity {
         return new AdminSystemEntity(
             adminSystemAggregate.getId().value(),
             adminSystemAggregate.isPostCollectionEnabled(),
-            adminSystemAggregate.getPostCollectionDelay()
+            adminSystemAggregate.getPostCollectionDelay(),
+            adminSystemAggregate.getCoreThreadPoolSize()
         );
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/entity/AdminSystemEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/entity/AdminSystemEntity.java
@@ -28,17 +28,21 @@ public class AdminSystemEntity {
     @Column(name = "post_collection_delay")
     private Long postCollectionDelay;
 
+    @Column(name = "post_collection_batch_size")
+    private Integer postCollectionBatchSize;
+
     @Column(name = "core_thread_pool_size")
     private Integer coreThreadPoolSize;
 
     @Builder
     protected AdminSystemEntity(
         Long id, boolean postCollectionEnabled, Long postCollectionDelay,
-        Integer coreThreadPoolSize
+        Integer postCollectionBatchSize, Integer coreThreadPoolSize
     ) {
         this.id = id;
         this.postCollectionEnabled = postCollectionEnabled;
         this.postCollectionDelay = postCollectionDelay;
+        this.postCollectionBatchSize = postCollectionBatchSize;
         this.coreThreadPoolSize = coreThreadPoolSize;
     }
 
@@ -48,15 +52,17 @@ public class AdminSystemEntity {
             .postCollectionEnabled(postCollectionEnabled)
             .postCollectionDelay(postCollectionDelay)
             .coreThreadPoolSize(coreThreadPoolSize)
+            .postCollectionBatchSize(postCollectionBatchSize)
             .build();
     }
 
     public static AdminSystemEntity from(AdminSystemAggregate adminSystemAggregate) {
-        return new AdminSystemEntity(
-            adminSystemAggregate.getId().value(),
-            adminSystemAggregate.isPostCollectionEnabled(),
-            adminSystemAggregate.getPostCollectionDelay(),
-            adminSystemAggregate.getCoreThreadPoolSize()
-        );
+        return AdminSystemEntity.builder()
+            .id(adminSystemAggregate.getId().value())
+            .postCollectionEnabled(adminSystemAggregate.isPostCollectionEnabled())
+            .postCollectionDelay(adminSystemAggregate.getPostCollectionDelay())
+            .postCollectionBatchSize(adminSystemAggregate.getPostCollectionBatchSize())
+            .coreThreadPoolSize(adminSystemAggregate.getCoreThreadPoolSize())
+            .build();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/system/PostCollectionThreadPoolExecutor.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/system/PostCollectionThreadPoolExecutor.java
@@ -3,6 +3,7 @@ package com.flytrap.rssreader.api.admin.infrastructure.system;
 import com.flytrap.rssreader.api.admin.domain.AdminSystemAggregate;
 import com.flytrap.rssreader.api.admin.infrastructure.implementation.AdminSystemCommand;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -49,7 +50,11 @@ public class PostCollectionThreadPoolExecutor implements CommandLineRunner {
         threadPoolTaskExecutor.execute(task);
     }
 
-    public CompletableFuture<Void> runAsync(Runnable task) {
-        return CompletableFuture.runAsync(task, threadPoolTaskExecutor);
+    public <T> CompletableFuture<T> supplyAsync(Supplier<T> task) {
+        return CompletableFuture.supplyAsync(task, threadPoolTaskExecutor);
+    }
+
+    public int getCorePoolSize() {
+        return threadPoolTaskExecutor.getCorePoolSize();
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/system/PostCollectionThreadPoolExecutor.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/infrastructure/system/PostCollectionThreadPoolExecutor.java
@@ -1,0 +1,55 @@
+package com.flytrap.rssreader.api.admin.infrastructure.system;
+
+import com.flytrap.rssreader.api.admin.domain.AdminSystemAggregate;
+import com.flytrap.rssreader.api.admin.infrastructure.implementation.AdminSystemCommand;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostCollectionThreadPoolExecutor implements CommandLineRunner {
+
+    private final AdminSystemCommand adminSystemCommand;
+    private ThreadPoolTaskExecutor threadPoolTaskExecutor;
+
+    @Override
+    public void run(String... args) throws Exception {
+        AdminSystemAggregate adminSystemAggregate = adminSystemCommand.read();
+
+        threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setThreadNamePrefix("postCollect-");
+        threadPoolTaskExecutor.setCorePoolSize(adminSystemAggregate.getCoreThreadPoolSize());
+        threadPoolTaskExecutor.setMaxPoolSize(adminSystemAggregate.getCoreThreadPoolSize());
+        threadPoolTaskExecutor.initialize();
+    }
+
+    /**
+     * ThreadPool의 core size를 재지정한다.
+     * 현재 작업중인 task가 있다면 모두 수행한 뒤 corePoolSize가 변경되며
+     * ThreadPool 내부의 BlockingQueue에 작업 대기중이던 task들은 무시된다.
+     *
+     * @param corePoolSize 재지정할 ThreadPool의 core size
+     */
+    public synchronized void resetCorePoolSize(int corePoolSize) {
+        if (threadPoolTaskExecutor != null) {
+            threadPoolTaskExecutor.shutdown();
+        }
+
+        threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setThreadNamePrefix("postCollect-");
+        threadPoolTaskExecutor.setCorePoolSize(corePoolSize);
+        threadPoolTaskExecutor.setMaxPoolSize(corePoolSize);
+        threadPoolTaskExecutor.initialize();
+    }
+
+    public void execute(Runnable task) {
+        threadPoolTaskExecutor.execute(task);
+    }
+
+    public CompletableFuture<Void> runAsync(Runnable task) {
+        return CompletableFuture.runAsync(task, threadPoolTaskExecutor);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.api.admin.presentation.controller;
 
 import com.flytrap.rssreader.api.admin.business.service.AdminSystemService;
+import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionCoreSizeRequest;
 import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionCycleRequest;
 import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionDelayRequest;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
@@ -91,6 +92,16 @@ public class AdminController {
         adminSystemService.changePostCollectionDelay(request.getDelay());
 
         return new ApplicationResponse<>("게시글 수집 스케쥴 간격 변경: " + request.getDelay() + "ms");
+    }
+
+    @PatchMapping("/api/admin/post-collection/core-size")
+    public ApplicationResponse<String> changePostCollectionThreadPoolCoreSize(
+        @RequestBody @Valid PostCollectionCoreSizeRequest request,
+        @AdminLogin AccountCredentials accountCredentials
+    ) {
+        adminSystemService.changePostCollectionThreadPoolCoreSize(request.getCoreSize());
+
+        return new ApplicationResponse<>("게시글 수집 코어 스레드 수 변경: " + request.getCoreSize() + "개");
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/controller/AdminController.java
@@ -1,8 +1,8 @@
 package com.flytrap.rssreader.api.admin.presentation.controller;
 
 import com.flytrap.rssreader.api.admin.business.service.AdminSystemService;
+import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionBatchSizeRequest;
 import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionCoreSizeRequest;
-import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionCycleRequest;
 import com.flytrap.rssreader.api.admin.presentation.dto.PostCollectionDelayRequest;
 import com.flytrap.rssreader.api.auth.presentation.dto.AccountCredentials;
 import com.flytrap.rssreader.api.auth.presentation.dto.LoginRequest;
@@ -75,7 +75,7 @@ public class AdminController {
 
     @PostMapping("/api/admin/post-collection/cycle")
     public ApplicationResponse<String> startPostCollectionCycle(
-        @RequestBody @Valid PostCollectionCycleRequest request,
+        @RequestBody @Valid PostCollectionBatchSizeRequest request,
         @AdminLogin AccountCredentials accountCredentials
     ) {
         adminSystemService.startPostCollectionCycle(request.getBatchSize());
@@ -92,6 +92,16 @@ public class AdminController {
         adminSystemService.changePostCollectionDelay(request.getDelay());
 
         return new ApplicationResponse<>("게시글 수집 스케쥴 간격 변경: " + request.getDelay() + "ms");
+    }
+
+    @PatchMapping("/api/admin/post-collection/batch-size")
+    public ApplicationResponse<String> changePostCollectionBatchSize(
+        @RequestBody @Valid PostCollectionBatchSizeRequest request,
+        @AdminLogin AccountCredentials accountCredentials
+    ) {
+        adminSystemService.changePostCollectionBatchSize(request.getBatchSize());
+
+        return new ApplicationResponse<>("게시글 수집 배치 사이즈 변경: " + request.getBatchSize());
     }
 
     @PatchMapping("/api/admin/post-collection/core-size")

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionBatchSizeRequest.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionBatchSizeRequest.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class PostCollectionCycleRequest {
+public class PostCollectionBatchSizeRequest {
 
     @Min(value = 1, message = "batchSize는 음수 값은 허용되지 않습니다.")
     @Max(value = 100_000, message = "batchSize는 100,000을 초과할 수 없습니다.")

--- a/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionCoreSizeRequest.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/presentation/dto/PostCollectionCoreSizeRequest.java
@@ -1,0 +1,15 @@
+package com.flytrap.rssreader.api.admin.presentation.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostCollectionCoreSizeRequest {
+
+    @Min(value = 1, message = "coreSize는 0보다 커야 합니다.")
+    @Max(value = 500 , message = "coreSize는 500을 초과할 수 없습니다.")
+    private int coreSize = 1;
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
@@ -1,12 +1,12 @@
 package com.flytrap.rssreader.api.post.business.service;
 
+import com.flytrap.rssreader.api.admin.domain.AdminSystemAggregate;
 import com.flytrap.rssreader.api.admin.infrastructure.implementation.AdminSystemCommand;
 import com.flytrap.rssreader.api.admin.infrastructure.system.PostCollectionEnableLoader;
 import com.flytrap.rssreader.api.post.infrastructure.system.PostCollectSystem;
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,40 +16,54 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PostCollectScheduledService implements CommandLineRunner {
 
-    @Value("${collector.subscribe-queue.select-batch-size}")
-    private int selectBatchSize;
     private ScheduledFuture<?> postCollectionScheduledFuture;
 
     private final PostCollectSystem postCollectSystem;
     private final PostCollectionEnableLoader postCollectionEnableLoader;
     private final AdminSystemCommand adminSystemCommand;
-    private final TaskScheduler taskScheduler;
+    private final TaskScheduler postCollectionTaskScheduler;
 
     @Override
     public void run(String... args) throws Exception {
-        long fixedDelayFromDb = adminSystemCommand.read().getPostCollectionDelay();
+        AdminSystemAggregate adminSystemAggregate = adminSystemCommand.read();
+        int batchSize = adminSystemAggregate.getPostCollectionBatchSize();
+        long delay = adminSystemAggregate.getPostCollectionDelay();
 
-        Runnable task = this::schedulePostCollection;
-        postCollectionScheduledFuture = taskScheduler
-            .scheduleWithFixedDelay(task, Duration.ofMillis(fixedDelayFromDb));
+        Runnable task = () -> this.schedulePostCollection(batchSize);
+        postCollectionScheduledFuture = postCollectionTaskScheduler
+            .scheduleWithFixedDelay(task, Duration.ofMillis(delay));
     }
 
-    public void changePostCollectionDelay(int delay) {
-        postCollectionScheduledFuture.cancel(true);
+    public void restartPostCollection() {
+        AdminSystemAggregate adminSystemAggregate = adminSystemCommand.read();
+        int batchSize = adminSystemAggregate.getPostCollectionBatchSize();
+        long delay = adminSystemAggregate.getPostCollectionDelay();
 
-        Runnable task = this::schedulePostCollection;
-        postCollectionScheduledFuture = taskScheduler.scheduleWithFixedDelay(task, Duration.ofMillis(delay));
+        if (postCollectionScheduledFuture != null) {
+            postCollectionScheduledFuture.cancel(true);
+        }
+
+        Runnable task = () -> this.schedulePostCollection(batchSize);
+        postCollectionScheduledFuture = postCollectionTaskScheduler
+            .scheduleWithFixedDelay(task, Duration.ofMillis(delay));
     }
 
-    public void schedulePostCollection() {
+    public void schedulePostCollection(int collectionBatchSize) {
 
         if (postCollectionEnableLoader.isDisabled()) {
             return;
         }
-
-        postCollectSystem.loadAndEnqueueRssResources(selectBatchSize);
+        System.out.println("수집 시작 배치사이즈: " + collectionBatchSize);
+        postCollectSystem.loadAndEnqueueRssResources(collectionBatchSize);
     }
 
+    /**
+     * 게시글 수집(schedulePostCollection)과 게시글 저장(schedulePostPersistence)
+     * Scheduled을 따로 쓰는 이유:
+     * 기존에 저장된 RSS 문서의 게시글 수집은 딜레이가 있어도 되지만
+     * 회원이 신규 RSS 문서 추가하면 추가한 즉시 해당 문서의 게시글을 저장해서 회원에게 보여줘야 되기 때문입니다.
+     * 따라서 게시글 저장(schedulePostPersistence)은 1000ms 마다 실행됩니다.
+     */
     @Scheduled(fixedDelay = 1000)
     public void schedulePostPersistence() {
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostSystemEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostSystemEntity.java
@@ -1,0 +1,51 @@
+package com.flytrap.rssreader.api.post.infrastructure.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "post_system")
+public class PostSystemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Instant startTime;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Instant endTime;
+
+    private Long elapsedTimeMillis;
+    private Integer rssCount;
+    private Integer postCount;
+    private Integer threadCount;
+    private Integer parsingFailureCount;
+
+    @Builder
+    protected PostSystemEntity(Long id, Instant startTime, Instant endTime, Long elapsedTimeMillis,
+        Integer rssCount, Integer postCount, Integer threadCount, Integer parsingFailureCount) {
+        this.id = id;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.elapsedTimeMillis = elapsedTimeMillis;
+        this.rssCount = rssCount;
+        this.postCount = postCount;
+        this.threadCount = threadCount;
+        this.parsingFailureCount = parsingFailureCount;
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostSystemJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostSystemJpaRepository.java
@@ -1,0 +1,8 @@
+package com.flytrap.rssreader.api.post.infrastructure.repository;
+
+import com.flytrap.rssreader.api.post.infrastructure.entity.PostSystemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostSystemJpaRepository extends JpaRepository<PostSystemEntity, Long> {
+
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/CollectionResult.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/CollectionResult.java
@@ -1,0 +1,12 @@
+package com.flytrap.rssreader.api.post.infrastructure.system;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CollectionResult {
+    private int rssCount;
+    private int postCount;
+    private int parsingFailureCount;
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
@@ -5,10 +5,13 @@ import com.flytrap.rssreader.api.alert.business.event.NewPostAlertEvent;
 import com.flytrap.rssreader.api.parser.RssPostParser;
 import com.flytrap.rssreader.api.parser.dto.RssPostsData;
 import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
+import com.flytrap.rssreader.api.post.infrastructure.entity.PostSystemEntity;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostJpaRepository;
+import com.flytrap.rssreader.api.post.infrastructure.repository.PostSystemJpaRepository;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
 import com.flytrap.rssreader.global.event.GlobalEventPublisher;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,14 +33,10 @@ public class PostCollectSystem {
     private final SubscribeCollectionPriorityQueue collectionQueue;
     private final RssResourceJpaRepository rssResourceRepository;
     private final PostJpaRepository postRepository;
+    private final PostSystemJpaRepository postSystemJpaRepository;
     private final RssPostParser postParser;
     private final GlobalEventPublisher globalEventPublisher;
     private final PostCollectionThreadPoolExecutor postCollectionThreadPoolExecutor;
-
-    public void collectPosts(int selectBatchSize) {
-        loadAndEnqueueRssResources(selectBatchSize);
-        dequeueAndSaveRssResource();
-    }
 
     public void loadAndEnqueueRssResources(int selectBatchSize) {
         var pageable = PageRequest.of(
@@ -50,30 +49,71 @@ public class PostCollectSystem {
     }
 
     public void dequeueAndSaveRssResource() {
-        var now = Instant.now();
-        CompletableFuture<Void> future = new CompletableFuture<>();
+        Instant start = Instant.now();
+        List<CompletableFuture<CollectionResult>> futures = new ArrayList<>();
 
         while (!collectionQueue.isQueueEmpty()) {
 
             RssSourceEntity rssResource = collectionQueue.poll();
 
-            future = postCollectionThreadPoolExecutor.runAsync(() -> {
-                postParser.parseRssDocuments(rssResource.getUrl())
-                    .ifPresent(rssPostsData -> {
-                        postRepository.saveAll(
+            CompletableFuture<CollectionResult> future = postCollectionThreadPoolExecutor.supplyAsync(
+                () -> postParser.parseRssDocuments(rssResource.getUrl())
+                    .map(rssPostsData -> {
+                        List<PostEntity> postEntities = postRepository.saveAll(
                             generateCollectedPostsForUpsert(rssPostsData, rssResource));
                         rssResource.updateTitle(rssPostsData.rssSourceTitle());
-                        rssResource.updateLastCollectedAt(now);
+                        rssResource.updateLastCollectedAt(start);
                         rssResourceRepository.save(rssResource);
-                    });
-            });
+
+                        return new CollectionResult(1, postEntities.size(), 0);
+                    })
+                    .orElse(new CollectionResult(0, 0, 1)));
+
+            futures.add(future);
         }
 
-        future.join();
+        summarizeAndSaveCollectionResults(start, futures);
     }
 
     public void enqueueHighPrioritySubscription(RssSourceEntity rssSourceEntity) {
         collectionQueue.add(rssSourceEntity, CollectPriority.HIGH);
+    }
+
+    /**
+     * 멀티 스레드로 동시 작업한 게시글 수집 결과를 집계하여 DB에 저장한다.
+     *
+     * @param start 게시글 수집 시작 시간
+     * @param futures 게시글 수집 작업의 CompletableFuture 목록
+     */
+    private void summarizeAndSaveCollectionResults(
+        Instant start, List<CompletableFuture<CollectionResult>> futures
+    ) {
+        CompletableFuture<Void> allOf = CompletableFuture.allOf(
+            futures.toArray(new CompletableFuture[0]));
+        allOf.thenApply(voidResult -> futures.stream()
+                .map(CompletableFuture::join)
+                .reduce(new CollectionResult(0, 0, 0), (result1, result2) ->
+                    new CollectionResult(
+                        result1.getRssCount() + result2.getRssCount(),
+                        result1.getPostCount() + result2.getPostCount(),
+                        result1.getParsingFailureCount() + result2.getParsingFailureCount()
+                    )
+                ))
+            .thenAccept(collectionResult -> {
+                Instant end = Instant.now();
+
+                postSystemJpaRepository.save(
+                    PostSystemEntity.builder()
+                        .startTime(start)
+                        .endTime(end)
+                        .elapsedTimeMillis(Duration.between(start, end).toMillis())
+                        .rssCount(collectionResult.getRssCount())
+                        .postCount(collectionResult.getPostCount())
+                        .threadCount(postCollectionThreadPoolExecutor.getCorePoolSize())
+                        .parsingFailureCount(collectionResult.getParsingFailureCount())
+                        .build()
+                );
+            }).join();
     }
 
     private List<PostEntity> generateCollectedPostsForUpsert(RssPostsData postData,

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
@@ -49,6 +49,10 @@ public class PostCollectSystem {
     }
 
     public void dequeueAndSaveRssResource() {
+        if (collectionQueue.isQueueEmpty()) {
+            return;
+        }
+
         Instant start = Instant.now();
         List<CompletableFuture<CollectionResult>> futures = new ArrayList<>();
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/SubscribeCollectionPriorityBlockingQueue.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/SubscribeCollectionPriorityBlockingQueue.java
@@ -40,4 +40,9 @@ public class SubscribeCollectionPriorityBlockingQueue implements SubscribeCollec
     public boolean isQueueEmpty() {
         return queue.isEmpty();
     }
+
+    @Override
+    public int size() {
+        return queue.size();
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/SubscribeCollectionPriorityQueue.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/SubscribeCollectionPriorityQueue.java
@@ -8,4 +8,5 @@ public interface SubscribeCollectionPriorityQueue {
     void addAll(List<RssSourceEntity> subscribes, CollectPriority priority);
     RssSourceEntity poll();
     boolean isQueueEmpty();
+    int size();
 }

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -78,15 +78,17 @@ CREATE TABLE IF NOT EXISTS `alert`
 
 CREATE TABLE IF NOT EXISTS `admin_system`
 (
-    `id`                        bigint  NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `post_collection_enabled`   tinyint(1)   NOT NULL DEFAULT 0,
-    `post_collection_delay`     bigint
+    `id`                            bigint  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `post_collection_enabled`       tinyint(1)   NOT NULL DEFAULT 0,
+    `post_collection_delay`         bigint,
+    `post_collection_batch_size`    int,
+    `core_thread_pool_size`         int
 );
 
 CREATE TABLE IF NOT EXISTS `rss_post_stat`
 (
-    `id`           bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `platform`	varchar(25)	NOT NULL,
-    `post_count`    bigint        NOT NULL,
-    `pub_date`      timestamp     NOT NULL
+    `id`            bigint          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `platform`	    varchar(25)	    NOT NULL,
+    `post_count`    bigint          NOT NULL,
+    `pub_date`      timestamp       NOT NULL
 );

--- a/src/test/resources/db/data.sql
+++ b/src/test/resources/db/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO `admin_system`(post_collection_enabled, post_collection_delay)
-VALUES (false, 1000);
+INSERT INTO `admin_system`(post_collection_enabled, post_collection_delay, post_collection_batch_size, core_thread_pool_size)
+VALUES (false, 1000, 50, 1);


### PR DESCRIPTION
# 🔑 Key Changes
- 게시글 수집에 멀티 스레드 적용

# 👩‍💻 To Reviewers
## 게시글 수집에 멀티 스레드 적용

## 게시글 수집 후 결과 데이터 저장
- `PostSystemEntity`로 게시글 수집 결과를 저장합니다. 아래의 데이터들을 저장합니다.
  - 게시글 수집 시작 시간
  - 게시글 수집 종료 시간
  - 파싱한 RSS 문서 수
  - 수집한 게시글 수
  - 게시글 수집 작업에 사용된 스레드 수 
  - RSS문서 파싱에 실패한 수

## 게시글 수집시 사용할 스레드 수 병경 API 추가
- admin만 접근 가능

### API
|Method|URI|
|---|---|
|`PATCH`|`/api/admin/post-collection/core-size`|

### Request
|name|type|description|
|---|---|---|
|coreSize|int|게시글 수집에 사용할 스레드 수. (min=1, max=500)|

## 게시글 수집 사이클당 수집할 RSS 문서 수 변경 API 추가
- admin만 접근 가능

### API
|Method|URI|
|---|---|
|`PATCH`|`/api/admin/post-collection/batch-size`|

### Request
|name|type|description|
|---|---|---|
|batchSize|int|게시글 수집 사이클당 수집할 RSS 문서 수. (min=1, max=100,000)|

# Related to
- #259 
