### PR TITLE
게시글 수집 bulk upsert로 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+    // MyBatis
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 }
 
 test {
@@ -98,7 +100,8 @@ tasks.named('test') {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.required = true
+        html.required = true
+        xml.required = false
         csv.required = false
     }
     finalizedBy 'jacocoTestCoverageVerification'
@@ -116,30 +119,14 @@ jacocoTestCoverageVerification { // TODO test coverage check
 //            element = 'CLASS'
 
             limit {
-                minimum = 0.01
+                minimum = 0.5
             }
-            excludes = [
-                    'com.flytrap.**.api.*',
-                    'com.flytrap.**.properties.*',
-                    'com.flytrap.**.exception.*',
-                    'com.flytrap.**.dto.*',
-                    'com.flytrap.**.output.*',
-                    'com.flytrap.**.entity.*',
-                    'com.flytrap.rssreader.global.**.*',
-                    'com.flytrap.**.config.*',
-                    'com.flytrap.**.model.*',
-                    'com.flytrap.**.repository.*',
-                    'com.flytrap.**.service.*ReadService',
-                    'com.flytrap.**.controller.*ReadController',
-                    'com.flytrap.**.controller.api.*',
-                    'com.flytrap.**.**.*Builder',
-                    'com.flytrap.**.**.*Resolver',
-                    'com.flytrap.**.**.*Context',
-                    'com.flytrap.**.**.*Event',
-                    'com.flytrap.**.**.*Publisher',
-                    'com.flytrap.**.RssReaderApplication',
-//                    '*.test.*',
-            ] + Qdomains
+
+            includes = [
+                    'com.flytrap.rssreader.api.**.business.service.*',
+                    'com.flytrap.rssreader.api.**.presentation.controller.*'
+            ]
+
         }
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/account/domain/Account.java
+++ b/src/main/java/com/flytrap/rssreader/api/account/domain/Account.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "account")
-public class Account implements DefaultDomain {
+public class Account implements DefaultDomain<Long> {
 
     private final AccountId id;
     private final AccountName name;

--- a/src/main/java/com/flytrap/rssreader/api/account/domain/AccountId.java
+++ b/src/main/java/com/flytrap/rssreader/api/account/domain/AccountId.java
@@ -4,10 +4,10 @@ import com.flytrap.rssreader.global.model.DomainId;
 import java.io.Serializable;
 
 public record AccountId(
-        long value
-) implements DomainId, Serializable  {
+        Long value
+) implements DomainId<Long>, Serializable  {
     public AccountId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("Account id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemAggregate.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "post")
-public class AdminSystemAggregate implements DefaultDomain {
+public class AdminSystemAggregate implements DefaultDomain<Long> {
 
     private final AdminSystemId id;
     private boolean postCollectionEnabled;

--- a/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemId.java
+++ b/src/main/java/com/flytrap/rssreader/api/admin/domain/AdminSystemId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.admin.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record AdminSystemId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public AdminSystemId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("AdminSystem id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/alert/domain/Alert.java
+++ b/src/main/java/com/flytrap/rssreader/api/alert/domain/Alert.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @Domain(name = "alert")
-public class Alert  implements DefaultDomain {
+public class Alert  implements DefaultDomain<Long> {
 
     private final AlertId id;
     private final AccountId accountId;

--- a/src/main/java/com/flytrap/rssreader/api/alert/domain/AlertId.java
+++ b/src/main/java/com/flytrap/rssreader/api/alert/domain/AlertId.java
@@ -3,11 +3,11 @@ package com.flytrap.rssreader.api.alert.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record AlertId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
 
     public AlertId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("Alert id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/folder/domain/Folder.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/domain/Folder.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Builder
 @Getter
-public class Folder implements DefaultDomain {
+public class Folder implements DefaultDomain<Long> {
     private final FolderId id;
     private final String name;
     private final AccountId ownerId;

--- a/src/main/java/com/flytrap/rssreader/api/folder/domain/FolderAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/domain/FolderAggregate.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class FolderAggregate implements DefaultDomain {
+public class FolderAggregate implements DefaultDomain<Long> {
 
     private final FolderId id;
     private String name;

--- a/src/main/java/com/flytrap/rssreader/api/folder/domain/FolderId.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/domain/FolderId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.folder.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record FolderId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public FolderId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("Folder id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/Post.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/Post.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "post")
-public class Post implements DefaultDomain<Long> {
+public class Post implements DefaultDomain<String> {
 
     private final PostId id;
     private final String guid;

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/Post.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/Post.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "post")
-public class Post implements DefaultDomain {
+public class Post implements DefaultDomain<Long> {
 
     private final PostId id;
     private final String guid;

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostAggregate.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "post")
-public class PostAggregate implements DefaultDomain {
+public class PostAggregate implements DefaultDomain<Long> {
 
     private final PostId id;
     private final String guid;

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostAggregate.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostAggregate.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "post")
-public class PostAggregate implements DefaultDomain<Long> {
+public class PostAggregate implements DefaultDomain<String> {
 
     private final PostId id;
     private final String guid;

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostId.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.post.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record PostId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public PostId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("Post id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostId.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostId.java
@@ -3,11 +3,11 @@ package com.flytrap.rssreader.api.post.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record PostId(
-    Long value
-) implements DomainId<Long> {
+    String value
+) implements DomainId<String> {
     public PostId {
-        if (value == null || value < 0) {
-            throw new IllegalArgumentException("Post id must be positive");
+        if (value == null) {
+            throw new IllegalArgumentException("Post ID cannot be null.");
         }
     }
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
@@ -1,0 +1,18 @@
+package com.flytrap.rssreader.api.post.domain;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class PostIdGenerator {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    public static String generateString(Instant pubDate, long rssSourceId) {
+        ZonedDateTime zonedDateTime = pubDate.atZone(ZoneOffset.UTC);
+
+        return zonedDateTime.format(formatter) + "-" + rssSourceId;
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/BookmarkEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/BookmarkEntity.java
@@ -27,10 +27,10 @@ public class BookmarkEntity {
     private Long accountId;
 
     @Column(name = "post_id", nullable = false)
-    private Long postId;
+    private String postId;
 
     @Builder
-    protected BookmarkEntity(Long id, Long accountId, Long postId) {
+    protected BookmarkEntity(Long id, Long accountId, String postId) {
         this.id = id;
         this.accountId = accountId;
         this.postId = postId;

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/OpenEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/OpenEntity.java
@@ -27,10 +27,10 @@ public class OpenEntity {
     private Long accountId;
 
     @Column(name = "post_id", nullable = false)
-    private Long postId;
+    private String postId;
 
     @Builder
-    protected OpenEntity(Long id, Long accountId, Long postId) {
+    protected OpenEntity(Long id, Long accountId, String postId) {
         this.id = id;
         this.accountId = accountId;
         this.postId = postId;

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
@@ -6,13 +6,12 @@ import com.flytrap.rssreader.api.post.domain.Open;
 import com.flytrap.rssreader.api.post.domain.Post;
 import com.flytrap.rssreader.api.post.domain.PostAggregate;
 import com.flytrap.rssreader.api.post.domain.PostId;
+import com.flytrap.rssreader.api.post.domain.PostIdGenerator;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.global.exception.domain.InconsistentDomainException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
@@ -32,20 +31,19 @@ import lombok.NoArgsConstructor;
 public class PostEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
-    @Column(length = 2500, nullable = false)
+    @Column(length = 2500)
     private String guid;
 
-    @Column(length = 2500, nullable = false)
+    @Column(length = 2500)
     private String title;
 
-    @Column(length = 2500, nullable = true)
+    @Column(length = 2500)
     private String thumbnailUrl;
 
     @Lob
-    @Column(columnDefinition = "LONGTEXT", nullable = false)
+    @Column(columnDefinition = "LONGTEXT")
     private String description;
 
     @Temporal(TemporalType.TIMESTAMP)
@@ -55,7 +53,7 @@ public class PostEntity {
     private Long rssSourceId;
 
     @Builder
-    protected PostEntity(Long id, String guid, String title, String thumbnailUrl, String description, Instant pubDate,
+    protected PostEntity(String id, String guid, String title, String thumbnailUrl, String description, Instant pubDate,
                          Long rssSourceId) {
         this.id = id;
         this.guid = guid;
@@ -66,8 +64,9 @@ public class PostEntity {
         this.rssSourceId = rssSourceId;
     }
 
-    public static PostEntity from(RssPostsData.RssItemData itemData, Long rssSourceId) {
+    public static PostEntity create(RssPostsData.RssItemData itemData, Long rssSourceId) {
         return PostEntity.builder()
+                .id(PostIdGenerator.generateString(itemData.pubDate(), rssSourceId))
                 .guid(itemData.guid())
                 .title(itemData.title())
                 .thumbnailUrl(itemData.thumbnailUrl())

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
@@ -15,8 +15,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -46,7 +44,7 @@ public class PostEntity {
     @Column(columnDefinition = "LONGTEXT")
     private String description;
 
-    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "pub_date", columnDefinition = "TIMESTAMP")
     private Instant pubDate;
 
     @Column(nullable = false)

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
@@ -13,7 +13,7 @@ import com.flytrap.rssreader.api.post.infrastructure.repository.PostDslRepositor
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostJpaRepository;
 import com.flytrap.rssreader.api.post.infrastructure.repository.PostOpenJpaRepository;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
-import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
+import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssSourceJpaRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +29,13 @@ public class PostQuery {
     private final BookmarkJpaRepository bookmarkJpaRepository;
     private final PostOpenJpaRepository postOpenJpaRepository;
     private final PostDslRepository postDslRepository;
-    private final RssResourceJpaRepository rssResourceJpaRepository;
+    private final RssSourceJpaRepository rssSourceJpaRepository;
 
     @Transactional(readOnly = true)
     public Optional<Post> read(PostId postId, AccountId accountId) {
 
         return postJpaRepository.findById(postId.value())
-            .flatMap(postEntity -> rssResourceJpaRepository.findById(postEntity.getId())
+            .flatMap(postEntity -> rssSourceJpaRepository.findById(postEntity.getId())
                 .map(rssSourceEntity -> {
                     boolean isRead = postOpenJpaRepository
                         .existsByAccountIdAndPostId(accountId.value(), postId.value());

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/implementation/PostQuery.java
@@ -35,7 +35,7 @@ public class PostQuery {
     public Optional<Post> read(PostId postId, AccountId accountId) {
 
         return postJpaRepository.findById(postId.value())
-            .flatMap(postEntity -> rssSourceJpaRepository.findById(postEntity.getId())
+            .flatMap(postEntity -> rssSourceJpaRepository.findById(postEntity.getRssSourceId())
                 .map(rssSourceEntity -> {
                     boolean isRead = postOpenJpaRepository
                         .existsByAccountIdAndPostId(accountId.value(), postId.value());

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/output/PostSummaryOutput.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/output/PostSummaryOutput.java
@@ -9,7 +9,7 @@ import com.flytrap.rssreader.api.post.domain.PostId;
 import java.time.Instant;
 
 public record PostSummaryOutput(
-        Long id,
+        String id,
         Long rssSourceId,
         String guid,
         String title,

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/BookmarkJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/BookmarkJpaRepository.java
@@ -4,7 +4,7 @@ import com.flytrap.rssreader.api.post.infrastructure.entity.BookmarkEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkJpaRepository extends JpaRepository<BookmarkEntity, Long> {
-    boolean existsByAccountIdAndPostId(Long memberId, Long postId);
+    boolean existsByAccountIdAndPostId(Long memberId, String postId);
 
-    void deleteByAccountIdAndPostId(Long memberId, Long postId);
+    void deleteByAccountIdAndPostId(Long memberId, String postId);
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface PostDslRepository {
 
-    Optional<PostSummaryOutput> findById(Long postId);
+    Optional<PostSummaryOutput> findById(String postId);
 
     List<PostSummaryOutput> findAllByAccount(long accountId, PostFilter postFilter, Pageable pageable);
 

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepositoryImpl.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostDslRepositoryImpl.java
@@ -31,7 +31,7 @@ public class PostDslRepositoryImpl implements PostDslRepository {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 
-    public Optional<PostSummaryOutput> findById(Long postId) {
+    public Optional<PostSummaryOutput> findById(String postId) {
 
         BooleanBuilder builder = new BooleanBuilder();
         builder

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostJpaRepository.java
@@ -1,11 +1,9 @@
 package com.flytrap.rssreader.api.post.infrastructure.repository;
 
 import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
-
-    List<PostEntity> findAllByRssSourceId(long rssSourceId);
-
+public interface PostJpaRepository extends JpaRepository<PostEntity, String> {
+    Optional<PostEntity> findFirstByRssSourceIdOrderByPubDateDesc(long rssSourceId);
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisRepository.java
@@ -1,0 +1,11 @@
+package com.flytrap.rssreader.api.post.infrastructure.repository;
+
+import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostMyBatisRepository {
+
+    int bulkUpsert(List<PostEntity> postEntities);
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostOpenJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostOpenJpaRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostOpenJpaRepository extends JpaRepository<OpenEntity, Long> {
 
-    boolean existsByAccountIdAndPostId(Long accountId, Long postId);
+    boolean existsByAccountIdAndPostId(Long accountId, String postId);
 
-    void deleteByAccountIdAndPostId(long memberId, Long postId);
+    void deleteByAccountIdAndPostId(long memberId, String postId);
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandController.java
@@ -25,7 +25,7 @@ public class PostCommandController implements PostCommandControllerApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/api/posts/{postId}/read")
     public ApplicationResponse<Void> unmarkAsOpened(
-        @PathVariable Long postId,
+        @PathVariable String postId,
         @Login AccountCredentials accountCredentials
     ) {
         postCommandService.unmarkAsOpen(new AccountId(accountCredentials.id().value()), new PostId(postId));
@@ -36,7 +36,7 @@ public class PostCommandController implements PostCommandControllerApi {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/posts/{postId}/bookmarks")
     public ApplicationResponse<BookmarkResponse> markAsBookmark(
-        @PathVariable Long postId,
+        @PathVariable String postId,
         @Login AccountCredentials accountCredentials
     ) {
         postCommandService
@@ -48,7 +48,7 @@ public class PostCommandController implements PostCommandControllerApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/api/posts/{postId}/bookmarks")
     public ApplicationResponse<Void> unmarkAsBookmark(
-        @PathVariable Long postId,
+        @PathVariable String postId,
         @Login AccountCredentials accountCredentials
     ) {
         postCommandService

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryController.java
@@ -21,7 +21,7 @@ public class PostQueryController implements PostQueryControllerApi {
 
     @GetMapping("/api/posts/{postId}")
     public ApplicationResponse<PostResponse> getPost(
-        @PathVariable Long postId,
+        @PathVariable String postId,
         @Login AccountCredentials accountCredentials) {
 
         PostResponse response = PostResponse.from(

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostCommandControllerApi.java
@@ -19,7 +19,7 @@ public interface PostCommandControllerApi {
         @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = BookmarkResponse.class))),
     })
     ApplicationResponse<BookmarkResponse> markAsBookmark(
-        @Parameter(description = "북마크에 추가할 게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "북마크에 추가할 게시글 ID") @PathVariable String postId,
         @Parameter(description = "현재 로그인한 회원 정보") @Login AccountCredentials member
     );
 
@@ -28,7 +28,7 @@ public interface PostCommandControllerApi {
         @ApiResponse(responseCode = "200", description = "성공",  content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
     })
     ApplicationResponse<Void> unmarkAsBookmark(
-        @Parameter(description = "북마크를 제거할 게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "북마크를 제거할 게시글 ID") @PathVariable String postId,
         @Parameter(description = "현재 로그인한 회원 정보") @Login AccountCredentials member
     );
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostQueryControllerApi.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/controller/swagger/PostQueryControllerApi.java
@@ -20,7 +20,7 @@ public interface PostQueryControllerApi {
             @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType="application/json", schema = @Schema(implementation = PostResponse.class))),
     })
     ApplicationResponse<PostResponse> getPost(
-            @PathVariable Long postId,
+            @PathVariable String postId,
             @Login AccountCredentials accountCredentials);
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/BookmarkResponse.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/BookmarkResponse.java
@@ -1,7 +1,7 @@
 package com.flytrap.rssreader.api.post.presentation.dto.response;
 
 public record BookmarkResponse(
-    Long accountId, Long postId
+    Long accountId, String postId
 ) {
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/PostResponse.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/presentation/dto/response/PostResponse.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import java.util.List;
 
 public record PostResponse(
-        long id,
+        String id,
         String guid,
         String title,
         String thumbnailUrl,

--- a/src/main/java/com/flytrap/rssreader/api/shared_member/domain/SharedMember.java
+++ b/src/main/java/com/flytrap/rssreader/api/shared_member/domain/SharedMember.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Domain(name = "sharedMember")
-public class SharedMember implements DefaultDomain {
+public class SharedMember implements DefaultDomain<Long> {
 
     private final SharedMemberId id;
     private final AccountId accountId;

--- a/src/main/java/com/flytrap/rssreader/api/shared_member/domain/SharedMemberId.java
+++ b/src/main/java/com/flytrap/rssreader/api/shared_member/domain/SharedMemberId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.shared_member.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record SharedMemberId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public SharedMemberId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("SharedMember id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RssSource.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RssSource.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @Domain(name = "rssSource")
-public class RssSource implements DefaultDomain {
+public class RssSource implements DefaultDomain<Long> {
 
     private final RssSourceId id;
     private final String title;

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RssSourceId.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RssSourceId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.subscribe.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record RssSourceId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public RssSourceId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("RssSource id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/Subscription.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/Subscription.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @Domain(name = "subscription")
-public class Subscription implements DefaultDomain {
+public class Subscription implements DefaultDomain<Long> {
 
     private final SubscriptionId id;
     private final String title;

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/SubscriptionId.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/SubscriptionId.java
@@ -3,10 +3,10 @@ package com.flytrap.rssreader.api.subscribe.domain;
 import com.flytrap.rssreader.global.model.DomainId;
 
 public record SubscriptionId(
-    long value
-) implements DomainId {
+    Long value
+) implements DomainId<Long> {
     public SubscriptionId {
-        if (value < 0) {
+        if (value == null || value < 0) {
             throw new IllegalArgumentException("Subscription id must be positive");
         }
     }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/RssSourceQuery.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/RssSourceQuery.java
@@ -3,7 +3,7 @@ package com.flytrap.rssreader.api.subscribe.infrastructure.implement;
 import com.flytrap.rssreader.api.subscribe.domain.RssSource;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
-import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
+import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssSourceJpaRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RssSourceQuery {
 
-    private final RssResourceJpaRepository rssResourceJpaRepository;
+    private final RssSourceJpaRepository rssSourceJpaRepository;
 
     public Optional<RssSource> read(RssSourceId rssSourceId) {
-        return rssResourceJpaRepository.findById(rssSourceId.value())
+        return rssSourceJpaRepository.findById(rssSourceId.value())
             .map(RssSourceEntity::toExistingRssSource);
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionCommand.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionCommand.java
@@ -9,7 +9,7 @@ import com.flytrap.rssreader.api.subscribe.domain.SubscriptionId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.SubscriptionEntity;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.SubscriptionJpaRepository;
-import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
+import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssSourceJpaRepository;
 import com.flytrap.rssreader.global.event.GlobalEventPublisher;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubscriptionCommand {
 
     private final SubscriptionJpaRepository subscriptionJpaRepository;
-    private final RssResourceJpaRepository rssResourceJpaRepository;
+    private final RssSourceJpaRepository rssSourceJpaRepository;
     private final RssSubscribeParser rssSubscribeParser;
     private final GlobalEventPublisher globalEventPublisher;
 
     @Transactional
     public Subscription createFrom(FolderId folderId, String rssUrl) {
-        Optional<RssSourceEntity> rssSourceEntityOptional = rssResourceJpaRepository
+        Optional<RssSourceEntity> rssSourceEntityOptional = rssSourceJpaRepository
             .findByUrl(rssUrl);
 
         if (rssSourceEntityOptional.isPresent()) {
@@ -42,7 +42,7 @@ public class SubscriptionCommand {
         } else {
             RssSourceData rssSourceData = rssSubscribeParser.parseRssDocuments(rssUrl)
                 .orElseThrow();
-            RssSourceEntity newRssSourceEntity = rssResourceJpaRepository
+            RssSourceEntity newRssSourceEntity = rssSourceJpaRepository
                 .save(RssSourceEntity.from(rssSourceData));
             SubscriptionEntity newSubscriptionEntity = SubscriptionEntity.builder()
                 .folderId(folderId.value())

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionValidator.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/implement/SubscriptionValidator.java
@@ -2,7 +2,7 @@ package com.flytrap.rssreader.api.subscribe.infrastructure.implement;
 
 import com.flytrap.rssreader.api.folder.domain.FolderId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.repository.SubscriptionDslRepository;
-import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssResourceJpaRepository;
+import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssSourceJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SubscriptionValidator {
 
-    private final RssResourceJpaRepository rssResourceJpaRepository;
+    private final RssSourceJpaRepository rssSourceJpaRepository;
     private final SubscriptionDslRepository subscriptionDslRepository;
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/repository/RssSourceJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/infrastructure/repository/RssSourceJpaRepository.java
@@ -4,9 +4,7 @@ import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RssResourceJpaRepository extends JpaRepository<RssSourceEntity, Long> {
-
-    boolean existsByUrl(String url);
+public interface RssSourceJpaRepository extends JpaRepository<RssSourceEntity, Long> {
 
     Optional<RssSourceEntity> findByUrl(String blogUrl);
 

--- a/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
@@ -1,15 +1,15 @@
 package com.flytrap.rssreader.global.model;
 
-public interface DefaultDomain {
+public interface DefaultDomain<T> {
 
-    public abstract DomainId getId();
+    DomainId<T> getId();
 
-    public default String getDomainCode() {
+    default String getDomainCode() {
         return this.getClass().getAnnotation(Domain.class).name();
     }
 
-    public default String getDomainCodeWithId() {
-        return String.format("%s_%d", this.getDomainCode(), this.getId().value());
+    default String getDomainCodeWithId() {
+        return String.format("%s_%s", this.getDomainCode(), this.getId().value().toString());
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/global/model/DomainId.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/DomainId.java
@@ -1,5 +1,5 @@
 package com.flytrap.rssreader.global.model;
 
-public interface DomainId {
-    long value();
+public interface DomainId<T> {
+    T value();
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,14 +22,16 @@ spring:
     store-type: redis
     redis:
       namespace: spring:session
+
   jpa:
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
+    show-sql: false
     hibernate:
-      # ddl-auto: create-drop
+      ddl-auto: create-drop
     defer-datasource-initialization: true
+
   data:
     redis:
       host: localhost
@@ -37,9 +39,12 @@ spring:
 
   sql:
     init:
-      # mode: always
+      mode: always
       schema-locations: classpath:/db/data.sql
 
   batch:
     job:
       enabled: false
+
+mybatis:
+  mapper-locations: classpath:mybatis/mappers/*.xml

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS `rss_source`
 
 CREATE TABLE IF NOT EXISTS `post`
 (
-    `id`            bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `id`            varchar(255)        NOT NULL PRIMARY KEY,
     `guid`          varchar(2500) NOT NULL,
     `rss_source_id` bigint        NOT NULL,
     `title`         varchar(2500) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS `post`
 CREATE TABLE IF NOT EXISTS `open`
 (
     `id`           bigint        NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `post_id`      bigint        NOT NULL,
+    `post_id`      varchar(255)        NOT NULL,
     `account_id`   bigint        NOT NULL
 );
 
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS `bookmark`
 (
     `id`	        bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `account_id`	bigint	NOT NULL,
-    `post_id` 	    bigint	NOT NULL
+    `post_id` 	    varchar(255)	NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS `alert`

--- a/src/main/resources/mybatis/mappers/PostMapper.xml
+++ b/src/main/resources/mybatis/mappers/PostMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTO Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.flytrap.rssreader.api.post.infrastructure.repository.PostMyBatisRepository">
+
+  <insert id="bulkUpsert" parameterType="com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity">
+    INSERT INTO post(id, guid, title, thumbnail_url, description, pub_date, rss_source_id)
+    VALUES
+    <foreach collection="list" index="index" item="p" separator=",">
+      (
+        #{p.id},
+        #{p.guid},
+        #{p.title},
+        #{p.thumbnailUrl},
+        #{p.description},
+        #{p.pubDate},
+        #{p.rssSourceId}
+      )
+    </foreach>
+    ON DUPLICATE KEY UPDATE
+      guid = VALUES(guid),
+      title = VALUES(title),
+      thumbnail_url = VALUES(thumbnail_url),
+      description = VALUES(description),
+      pub_date = VALUES(pub_date),
+      rss_source_id = VALUES(rss_source_id);
+  </insert>
+
+</mapper>

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostCommandServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostCommandServiceTest.java
@@ -33,7 +33,7 @@ class PostCommandServiceTest {
         void 게시글_읽음_상태를_취소할_수_있다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(1L);
+            var postId = new PostId("20240101000000-1");
 
             // when
             postCommandService.unmarkAsOpen(accountId, postId);
@@ -47,7 +47,7 @@ class PostCommandServiceTest {
         void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(999L);
+            var postId = new PostId("00000000000000-999");
 
             // when
             Executable postExecutable = () ->
@@ -67,7 +67,7 @@ class PostCommandServiceTest {
         void 북마크를_추가할_수_있다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(1L);
+            var postId = new PostId("20240101000000-1");
 
             // when
             postCommandService.markAsBookmark(accountId, postId);
@@ -81,7 +81,7 @@ class PostCommandServiceTest {
         void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(999L);
+            var postId = new PostId("00000000000000-999");
 
             // when
             Executable postExecutable = () ->
@@ -100,7 +100,7 @@ class PostCommandServiceTest {
         void 북마크를_취소할_수_있다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(1L);
+            var postId = new PostId("20240101000000-1");
 
             // when
             postCommandService.unmarkAsBookmark(accountId, postId);
@@ -114,7 +114,7 @@ class PostCommandServiceTest {
         void 존재하지_않는_게시글을_조작할_경우_예외를_던진다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(999L);
+            var postId = new PostId("00000000000000-999");
 
             // when
             Executable postExecutable = () ->

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostListQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostListQueryServiceTest.java
@@ -1,7 +1,6 @@
 package com.flytrap.rssreader.api.post.business.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.flytrap.rssreader.CustomServiceTest;
 import com.flytrap.rssreader.api.account.domain.AccountId;
@@ -104,14 +103,14 @@ class PostListQueryServiceTest {
 
             postCommand.updateOnlyBookmark(
                 PostAggregate.builder()
-                    .id(new PostId(1L))
+                    .id(new PostId("20240101000000-1"))
                     .bookmark(Bookmark.MARKED).build(),
                 accountId
             );
 
             postCommand.updateOnlyBookmark(
                 PostAggregate.builder()
-                    .id(new PostId(2L))
+                    .id(new PostId("20240101010000-1"))
                     .bookmark(Bookmark.MARKED).build(),
                 accountId
             );

--- a/src/test/java/com/flytrap/rssreader/api/post/business/service/PostQueryServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/business/service/PostQueryServiceTest.java
@@ -31,7 +31,7 @@ class PostQueryServiceTest {
         void 게시글_정보를_불러올_수_있다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(1L);
+            var postId = new PostId("20240101000000-1");
 
             // when
             var result = postQueryService.viewPost(accountId, postId);
@@ -44,7 +44,7 @@ class PostQueryServiceTest {
         void 존재하지_않는_게시글을_불러오면_예외가_발생한다() {
             // given
             var accountId = new AccountId(1L);
-            var postId = new PostId(999L);
+            var postId = new PostId("00000000000000-999");
 
             // when
             Executable viewPostExecutable = ()

--- a/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostCommandControllerTest.java
@@ -52,7 +52,7 @@ class PostCommandControllerTest {
         void 읽음_상태_취소_성공시_204응답을_반환한다() throws Exception {
             // given
             postCommand.updateOnlyOpen(
-                PostAggregate.builder().id(new PostId(1L)).open(Open.MARKED).build(),
+                PostAggregate.builder().id(new PostId("20240102000000-1")).open(Open.MARKED).build(),
                 new AccountId(1L)
             );
 
@@ -62,7 +62,7 @@ class PostCommandControllerTest {
             when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
                 .thenReturn(accountCredentials);
 
-            mockMvc.perform(delete("/api/posts/{postId}/read", 1))
+            mockMvc.perform(delete("/api/posts/{postId}/read", "20240101000000-1"))
                 .andExpect(status().isNoContent());
         }
 
@@ -93,7 +93,7 @@ class PostCommandControllerTest {
             when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
                 .thenReturn(accountCredentials);
 
-            mockMvc.perform(post("/api/posts/{postId}/bookmarks", 1))
+            mockMvc.perform(post("/api/posts/{postId}/bookmarks", "20240101000000-1"))
                 .andExpect(status().isCreated());
         }
 
@@ -107,7 +107,7 @@ class PostCommandControllerTest {
                 .thenThrow(AuthenticationException.class);
 
             // when, then
-            mockMvc.perform(post("/api/posts/{postId}/bookmarks", 1))
+            mockMvc.perform(post("/api/posts/{postId}/bookmarks", "20240101000000-1"))
                 .andExpect(status().isUnauthorized());
         }
 
@@ -121,7 +121,7 @@ class PostCommandControllerTest {
         void 북마크_취소_성공시_204응답을_반환한다() throws Exception {
             // given
             postCommand.updateOnlyBookmark(
-                PostAggregate.builder().id(new PostId(1L)).bookmark(Bookmark.MARKED).build(),
+                PostAggregate.builder().id(new PostId("20240102000000-1")).bookmark(Bookmark.MARKED).build(),
                 new AccountId(1L)
             );
 
@@ -131,7 +131,7 @@ class PostCommandControllerTest {
             when(authorizationArgumentResolver.resolveArgument(any(), any(), any(), any()))
                 .thenReturn(accountCredentials);
 
-            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", 1))
+            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", "20240101000000-1"))
                 .andExpect(status().isNoContent());
         }
 
@@ -144,7 +144,7 @@ class PostCommandControllerTest {
                 .thenThrow(AuthenticationException.class);
 
             // when, then
-            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", 1))
+            mockMvc.perform(delete("/api/posts/{postId}/bookmarks", "20240101000000-1"))
                 .andExpect(status().isUnauthorized());
         }
     }

--- a/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
+++ b/src/test/java/com/flytrap/rssreader/api/post/presentation/controller/PostQueryControllerTest.java
@@ -46,7 +46,7 @@ class PostQueryControllerTest {
                 .thenReturn(accountCredentials);
 
             // when, then
-            mockMvc.perform(get("/api/posts/{postId}", 1))
+            mockMvc.perform(get("/api/posts/{postId}", "20240101000000-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").hasJsonPath())
                 .andExpect(jsonPath("$.data.guid").hasJsonPath())
@@ -68,7 +68,7 @@ class PostQueryControllerTest {
                 .thenThrow(AuthenticationException.class);
 
             // when, then
-            mockMvc.perform(get("/api/posts/{postId}", 1))
+            mockMvc.perform(get("/api/posts/{postId}", "20240101000000-1"))
                 .andExpect(status().isUnauthorized());
         }
 

--- a/src/test/java/com/flytrap/rssreader/fixture/FixtureFactory.java
+++ b/src/test/java/com/flytrap/rssreader/fixture/FixtureFactory.java
@@ -3,45 +3,9 @@ package com.flytrap.rssreader.fixture;
 import com.flytrap.rssreader.api.account.domain.Account;
 import com.flytrap.rssreader.api.account.domain.AccountId;
 import com.flytrap.rssreader.api.account.domain.AccountName;
-import com.flytrap.rssreader.api.account.infrastructure.entity.AccountEntity;
-import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
-import com.flytrap.rssreader.api.subscribe.domain.BlogPlatform;
-import com.flytrap.rssreader.fixture.FixtureFields.MemberEntityFields;
 import com.flytrap.rssreader.fixture.FixtureFields.MemberFields;
-import com.flytrap.rssreader.fixture.FixtureFields.PostEntityFields;
-import com.flytrap.rssreader.fixture.FixtureFields.RssItemResourceFields;
-import com.flytrap.rssreader.fixture.FixtureFields.SubscribeEntityFields;
-import com.flytrap.rssreader.fixture.FixtureFields.UserResourceFields;
-import com.flytrap.rssreader.api.parser.dto.RssPostsData.RssItemData;
-import com.flytrap.rssreader.api.auth.infrastructure.external.dto.UserResource;
-import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
-import com.flytrap.rssreader.api.parser.dto.RssSourceData;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 public class FixtureFactory {
-
-    // Account
-    public static UserResource generateUserResource() {
-        return UserResource.builder()
-                .id(UserResourceFields.id)
-                .email(UserResourceFields.email)
-                .login(UserResourceFields.login)
-                .avatarUrl(UserResourceFields.avatarUrl)
-                .build();
-    }
-
-    public static AccountEntity generateAccountEntity() {
-        return AccountEntity.builder()
-                .id(MemberEntityFields.id)
-                .email(MemberEntityFields.email)
-                .name(MemberEntityFields.name)
-                .profile(MemberEntityFields.profile)
-                .providerKey(MemberEntityFields.oauthPk)
-                .authProvider(MemberEntityFields.authProvider)
-                .build();
-    }
 
     public static Account generateAccount() {
         return Account.builder()
@@ -52,90 +16,5 @@ public class FixtureFactory {
                 .providerKey(MemberFields.oauthPk)
                 .authProvider(MemberFields.authProvider)
                 .build();
-    }
-
-    public static Account generateAccount(Long id) {
-        return Account.builder()
-                .id(new AccountId(id))
-                .name(new AccountName(MemberFields.name))
-                .email(MemberFields.email)
-                .profile(MemberFields.profile)
-                .providerKey(MemberFields.oauthPk)
-                .authProvider(MemberFields.authProvider)
-                .build();
-    }
-
-    // Post
-    public static RssItemData generateRssItemData() {
-        return new RssItemData(
-                RssItemResourceFields.guid,
-                RssItemResourceFields.title,
-                RssItemResourceFields.description,
-                RssItemResourceFields.pubDate,
-                RssItemResourceFields.thumbnailUrl
-        );
-    }
-
-    public static List<RssItemData> generate50RssItemDataList() {
-        List<RssItemData> rssItemData = new ArrayList<>();
-        for (int i = 0; i < 50; i++) {
-            rssItemData.add(generateRssItemData());
-        }
-        return rssItemData;
-    }
-
-    public static PostEntity generatePostEntity(Long id) {
-        return PostEntity.builder()
-                .id(id)
-                .guid(PostEntityFields.guid)
-                .title(PostEntityFields.title)
-                .description(PostEntityFields.description)
-                .rssSourceId(PostEntityFields.subscribe.getId())
-                .build();
-    }
-
-    public static List<PostEntity> generate100PostEntityList() {
-        List<PostEntity> postEntities = new ArrayList<>();
-        for (int i = 1; i <= 100; i++) {
-            postEntities.add(generatePostEntity((long) i));
-        }
-
-        return postEntities;
-    }
-
-    // Subscribe
-    public static RssSourceEntity generateSubscribeEntity() {
-        return RssSourceEntity.builder()
-                .id(SubscribeEntityFields.id)
-                .url(SubscribeEntityFields.url)
-                .platform(SubscribeEntityFields.platform)
-                .build();
-    }
-
-    public static RssSourceEntity generateSubscribeEntity(Long id) {
-        return RssSourceEntity.builder()
-            .id(id)
-            .url(SubscribeEntityFields.url)
-            .platform(SubscribeEntityFields.platform)
-            .build();
-    }
-
-    public static List<RssSourceEntity> generateSubscribeEntityList(int times) {
-        List<RssSourceEntity> subscribeEntities = new ArrayList<>();
-        for (int i = 1; i <= times; i++) {
-            subscribeEntities.add(generateSubscribeEntity((long) i));
-        }
-
-        return subscribeEntities;
-    }
-
-    public static Optional<RssSourceData> generateRssSubscribeData() {
-        return Optional.of(new RssSourceData(
-                RssItemResourceFields.title,
-                //TODO: 깃허브, 티스토리도 추가하려면 테스트 코드를 바꿔야 할 듯 합니다.
-                "https://v2.velog.io/rss/jinny-l",
-                BlogPlatform.VELOG,
-                RssItemResourceFields.description
-        ));
     }
 }

--- a/src/test/java/com/flytrap/rssreader/fixture/FixtureFields.java
+++ b/src/test/java/com/flytrap/rssreader/fixture/FixtureFields.java
@@ -1,9 +1,6 @@
 package com.flytrap.rssreader.fixture;
 
 import com.flytrap.rssreader.api.account.domain.AuthProvider;
-import com.flytrap.rssreader.api.subscribe.domain.BlogPlatform;
-import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
-import java.time.Instant;
 
 public class FixtureFields {
 
@@ -12,29 +9,6 @@ public class FixtureFields {
     private static final String LOGIN = "login";
     private static final String NAME = "name";
     private static final String AVATAR_URL = "https://avatarUrl.jpg";
-    private static final String RSS_URL = "https://avatarUrl.jpg";
-    private static final String GUID = "guid";
-    private static final Instant INSTANT_20231115 = Instant.parse("2023-11-15T00:00:00Z");
-    private static final String TITLE = "title";
-    private static final String DESCRIPTION = "description";
-
-    public static class UserResourceFields {
-
-        public static Long id = LONG_1L;
-        public static String email = EMAIL_TEST_GMAIL;
-        public static String login = LOGIN;
-        public static String avatarUrl = AVATAR_URL;
-    }
-
-    public static class MemberEntityFields {
-
-        public static Long id = LONG_1L;
-        public static String email = EMAIL_TEST_GMAIL;
-        public static String name = NAME;
-        public static String profile = AVATAR_URL;
-        public static Long oauthPk = LONG_1L;
-        public static AuthProvider authProvider = AuthProvider.GITHUB;
-    }
 
     public static class MemberFields {
 
@@ -52,29 +26,4 @@ public class FixtureFields {
         public static AuthProvider anotherAuthProvider = AuthProvider.GITHUB;
     }
 
-    public static class RssItemResourceFields {
-
-        public static String guid = GUID;
-        public static String title = TITLE;
-        public static String description = DESCRIPTION;
-        public static Instant pubDate = INSTANT_20231115;
-        public static String thumbnailUrl = AVATAR_URL;
-    }
-
-    public static class SubscribeEntityFields {
-
-        public static Long id = LONG_1L;
-        public static String url = RSS_URL;
-        public static String description = DESCRIPTION;
-        public static BlogPlatform platform = BlogPlatform.VELOG;
-    }
-
-    public static class PostEntityFields {
-
-        public static Long id = LONG_1L;
-        public static String guid = GUID;
-        public static String title = TITLE;
-        public static String description = DESCRIPTION;
-        public static RssSourceEntity subscribe = FixtureFactory.generateSubscribeEntity();
-    }
 }

--- a/src/test/resources/db/post-sample.sql
+++ b/src/test/resources/db/post-sample.sql
@@ -1,13 +1,13 @@
 INSERT INTO `post`(id, guid, title, thumbnail_url, description, pub_date, rss_source_id)
 VALUES
-    (1, 'guid01', 'title01', 'url01', 'description01', '2024-01-01 00:00:00.000000', 1),
-    (2, 'guid02', 'title02', 'url02', 'description02', '2024-01-01 00:00:00.000000', 1),
-    (3, 'guid03', 'title03', 'url03', 'description03', '2024-01-01 00:00:00.000000', 2),
-    (4, 'guid04', 'title04', 'url04', 'description04', '2024-01-01 00:00:00.000000', 2),
-    (5, 'guid05', 'title05', 'url05', 'description05', '2024-01-01 00:00:00.000000', 3),
-    (6, 'guid06', 'title06', 'url06', 'description06', '2024-01-01 00:00:00.000000', 3),
-    (7, 'guid07', 'title07', 'url07', 'description07', '2024-01-01 00:00:00.000000', 4),
-    (8, 'guid08', 'title08', 'url08', 'description08', '2024-01-01 00:00:00.000000', 4);
+    ('20240101000000-1', 'guid01', 'title01', 'url01', 'description01', '2024-01-01 00:00:00.000000', 1),
+    ('20240101010000-1', 'guid02', 'title02', 'url02', 'description02', '2024-01-01 01:00:00.000000', 1),
+    ('20240101020000-2', 'guid03', 'title03', 'url03', 'description03', '2024-01-01 02:00:00.000000', 2),
+    ('20240101030000-2', 'guid04', 'title04', 'url04', 'description04', '2024-01-01 03:00:00.000000', 2),
+    ('20240101040000-3', 'guid05', 'title05', 'url05', 'description05', '2024-01-01 04:00:00.000000', 3),
+    ('20240101050000-3', 'guid06', 'title06', 'url06', 'description06', '2024-01-01 05:00:00.000000', 3),
+    ('20240101060000-4', 'guid07', 'title07', 'url07', 'description07', '2024-01-01 06:00:00.000000', 4),
+    ('20240101070000-4', 'guid08', 'title08', 'url08', 'description08', '2024-01-01 07:00:00.000000', 4);
 
 INSERT INTO `rss_source`(id, title, url, platform, last_collected_at)
 VALUES


### PR DESCRIPTION
# 🔑 Key Changes
- 게시글 수집 bulk upserta로 개선

# 👩‍💻 To Reviewers
## PostId 변경
- 변경 이유: 기존에 post를 구별하던 guid는 변경이 잦아서 게시글이 중복수집되는 문제가 자주 발생함
- 변경 사항: postId를 pub_date + rss_source_id 형태(`yyyyMMddHHmmss-[rss_source_id]`)의 문자열로 변경함 
  - post의 pub_date는 한번 발행하면 변경되지 않고 한 블로그에서 pub_date가 중복되는 경우는 이때까지 없었음
  - pub_date는 다른 블로그 끼리 겹칠 수 있기 때문에 pub_date 뒤에 rss_source_id를 추가함

## post 수집 query를 bulk upsert로 변경
- 기존에 사용하던 spring data jpa에서 제공하던 saveAll은 post 하나당 insert query가 나가고, Jpa Entity Manger에 영속성 객체가 없으면 select 해오는 query가 추가로 발생함
- post 수집 query를 bulk upsert로 변경하여 발생하는 query 수를 줄임

### MyBatis 추가
- MySQL의 upsert 기능을 사용하기 위해 추가함

## post 수집 알림 트리거 변경
- 기존 방식: post수집후 만들어진 PostEntity와 DB에서 불러온 PostEntity를 비교해서 DB에 없는 post면 알림을 보냄
  - 문제: 비교를 위해 수집할 RSS 마다 DB에서 post를 모두 select 해와야 함.
- 변경 사항: 게시글 수집시 RSS의 post에서 가장 최근 post만 불러와 해당 post의 pub_date 이후에 발행된 post만 신규 post로 인식하여 아림을 보내도록 변경함
  - 문제: 과거의 글을 비공개로 발행 -> 신규 개시글을 추가로 발행 -> 비공개로 발행했던 글을 공개로 전환 : 이 경우는 알림을 보낼 수 없음
  - 잘 일어나는 일은 아니라고 판단해 이 경우는 알림을 보내지 않는 것으로 결정함

# Related to
- #259 
