### PR TITLE
게시글 수집 ID 값 변경 및 게시글 수집 Upsert SQL 에러 수정

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/business/service/PostCollectScheduledService.java
@@ -53,7 +53,6 @@ public class PostCollectScheduledService implements CommandLineRunner {
         if (postCollectionEnableLoader.isDisabled()) {
             return;
         }
-        System.out.println("수집 시작 배치사이즈: " + collectionBatchSize);
         postCollectSystem.loadAndEnqueueRssResources(collectionBatchSize);
     }
 

--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
@@ -1,18 +1,31 @@
 package com.flytrap.rssreader.api.post.domain;
 
+import jakarta.xml.bind.DatatypeConverter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Component;
 
+@Component
 public class PostIdGenerator {
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+    private static final String hashAlgorithm = "SHA-1";
 
-    public static String generateString(Instant pubDate, long rssSourceId) {
+    public static PostId generateString(Instant pubDate, String guid)
+        throws NoSuchAlgorithmException
+    {
         ZonedDateTime zonedDateTime = pubDate.atZone(ZoneOffset.UTC);
 
-        return zonedDateTime.format(formatter) + "-" + rssSourceId;
+        MessageDigest messageDigest = MessageDigest.getInstance(hashAlgorithm);
+        byte[] digest = messageDigest.digest(guid.getBytes(StandardCharsets.UTF_8));
+        String hashValue = DatatypeConverter.printHexBinary(digest).toLowerCase();
+
+        return new PostId(zonedDateTime.format(formatter) + "-" + hashValue);
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
@@ -6,7 +6,6 @@ import com.flytrap.rssreader.api.post.domain.Open;
 import com.flytrap.rssreader.api.post.domain.Post;
 import com.flytrap.rssreader.api.post.domain.PostAggregate;
 import com.flytrap.rssreader.api.post.domain.PostId;
-import com.flytrap.rssreader.api.post.domain.PostIdGenerator;
 import com.flytrap.rssreader.api.subscribe.domain.RssSourceId;
 import com.flytrap.rssreader.api.subscribe.infrastructure.entity.RssSourceEntity;
 import com.flytrap.rssreader.global.exception.domain.InconsistentDomainException;
@@ -62,9 +61,9 @@ public class PostEntity {
         this.rssSourceId = rssSourceId;
     }
 
-    public static PostEntity create(RssPostsData.RssItemData itemData, Long rssSourceId) {
+    public static PostEntity create(PostId postId, RssPostsData.RssItemData itemData, Long rssSourceId) {
         return PostEntity.builder()
-                .id(PostIdGenerator.generateString(itemData.pubDate(), rssSourceId))
+                .id(postId.value())
                 .guid(itemData.guid())
                 .title(itemData.title())
                 .thumbnailUrl(itemData.thumbnailUrl())

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostEntity.java
@@ -28,6 +28,7 @@ import lombok.NoArgsConstructor;
 public class PostEntity {
 
     @Id
+    @Column(length = 55)
     private String id;
 
     @Column(length = 2500)

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostSystemEntity.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/entity/PostSystemEntity.java
@@ -34,10 +34,12 @@ public class PostSystemEntity {
     private Integer postCount;
     private Integer threadCount;
     private Integer parsingFailureCount;
+    private Integer insertFailureCount;
 
     @Builder
     protected PostSystemEntity(Long id, Instant startTime, Instant endTime, Long elapsedTimeMillis,
-        Integer rssCount, Integer postCount, Integer threadCount, Integer parsingFailureCount) {
+        Integer rssCount, Integer postCount, Integer threadCount, Integer parsingFailureCount,
+        Integer insertFailureCount) {
         this.id = id;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -46,6 +48,7 @@ public class PostSystemEntity {
         this.postCount = postCount;
         this.threadCount = threadCount;
         this.parsingFailureCount = parsingFailureCount;
+        this.insertFailureCount = insertFailureCount;
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisMapper.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisMapper.java
@@ -1,0 +1,10 @@
+package com.flytrap.rssreader.api.post.infrastructure.repository;
+
+import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostMyBatisMapper {
+    int bulkUpsert(List<PostEntity> postEntities);
+}

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisRepository.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/repository/PostMyBatisRepository.java
@@ -2,10 +2,28 @@ package com.flytrap.rssreader.api.post.infrastructure.repository;
 
 import com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity;
 import java.util.List;
-import org.apache.ibatis.annotations.Mapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
-@Mapper
-public interface PostMyBatisRepository {
+@Repository
+@RequiredArgsConstructor
+public class PostMyBatisRepository {
 
-    int bulkUpsert(List<PostEntity> postEntities);
+    private final PostMyBatisMapper postMyBatisMapper;
+
+    /**
+     * PostEntity를 Bulk Upsert합니다.
+     *
+     * PostEntity 리스트가 null이 아니거나 비어 있지 않은지 확인합니다.
+     * 리스트가 null이거나 비어 있으면 -1을 반환하여 오류 또는 작업이 수행되지 않았음을 나타냅니다.
+     *
+     * @param postEntities Bulk Upsert할 PostEntity 리스트
+     * @return 리스트가 null이거나 비어 있는 경우, 그외 에러가 나면 -1을 반환하고, 그렇지 않으면 bulk upsert된 Entity의 수를 결과를 반환합니다.
+     */
+    public int bulkUpsert(List<PostEntity> postEntities) {
+        if (postEntities == null || postEntities.isEmpty()) {
+            return -1;
+        }
+        return postMyBatisMapper.bulkUpsert(postEntities);
+    }
 }

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/CollectionResult.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/CollectionResult.java
@@ -9,4 +9,5 @@ public class CollectionResult {
     private int rssCount;
     private int postCount;
     private int parsingFailureCount;
+    private int insertFailureCount;
 }

--- a/src/main/resources/mybatis/mappers/PostMapper.xml
+++ b/src/main/resources/mybatis/mappers/PostMapper.xml
@@ -2,29 +2,36 @@
 
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTO Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.flytrap.rssreader.api.post.infrastructure.repository.PostMyBatisRepository">
+<mapper namespace="com.flytrap.rssreader.api.post.infrastructure.repository.PostMyBatisMapper">
 
   <insert id="bulkUpsert" parameterType="com.flytrap.rssreader.api.post.infrastructure.entity.PostEntity">
-    INSERT INTO post(id, guid, title, thumbnail_url, description, pub_date, rss_source_id)
-    VALUES
-    <foreach collection="list" index="index" item="p" separator=",">
-      (
-        #{p.id},
-        #{p.guid},
-        #{p.title},
-        #{p.thumbnailUrl},
-        #{p.description},
-        #{p.pubDate},
-        #{p.rssSourceId}
-      )
-    </foreach>
-    ON DUPLICATE KEY UPDATE
-      guid = VALUES(guid),
-      title = VALUES(title),
-      thumbnail_url = VALUES(thumbnail_url),
-      description = VALUES(description),
-      pub_date = VALUES(pub_date),
-      rss_source_id = VALUES(rss_source_id);
+    <choose>
+      <when test="list != null and list.size() > 0">
+        INSERT INTO post(id, guid, title, thumbnail_url, description, pub_date, rss_source_id)
+        VALUES
+        <foreach collection="list" index="index" item="p" separator=",">
+          (
+          #{p.id},
+          #{p.guid},
+          #{p.title},
+          #{p.thumbnailUrl},
+          #{p.description},
+          #{p.pubDate},
+          #{p.rssSourceId}
+          )
+        </foreach>
+        ON DUPLICATE KEY UPDATE
+        guid = VALUES(guid),
+        title = VALUES(title),
+        thumbnail_url = VALUES(thumbnail_url),
+        description = VALUES(description),
+        pub_date = VALUES(pub_date),
+        rss_source_id = VALUES(rss_source_id);
+      </when>
+      <otherwise>
+        SELECT 1
+      </otherwise>
+    </choose>
   </insert>
 
 </mapper>


### PR DESCRIPTION
# 🔑 Key Changes
- 게시글 수집 ID 값 변경
- 게시글 수집 Upsert SQL 에러 수정

# 👩‍💻 To Reviewers
## 게시글 수집 ID 값 변경
- 기존 Post Id : pub_date + rss_source_id 값
- 문제: 특정 블로그에서 같은 pub_date의 게시글을 대량으로 게시하는 것을 발견함.
- 변경된 Post Id: pub_date + guid hash값
- 이유: 결국 게시글 데이터 중 변하지 않는 값은 없어서. 그나마 겹치는 경우가 적은 guid를 사용하기로 함.
  - 개발 초기에 guid는 길이가 너무 긴 경우가 있어 pk로 사용하지 않았는데, guid를 hash 값으로 변환해서 길이를 줄임
  - hash 알고리즘은 SHA-1로 정함. SHA-256은 너무 길이가 길어서 반려함
  - 게시글이 많아지면 hash 충돌이 발생할 수 있는데, id 앞에 pub_date를 붙여서 id가 중복될 확률을 줄임

## 게시글 수집 Upsert SQL 에러 수정
- 기능 테스트 도중 RSS 문서 파싱에 성공해도 수집한 게시글이 없는 경우 INSERT 과정에서 에럭가 남
- Bulk Upsert SQL 문을 만드는 과정에서 게시글 리스트가 비어 있으면 SQL문을 제대로 만들지 못해서 발생한 문제
- 수집한 게시글 리스트가 비어 있거나 null일때 SQL을 실행하지 않도록 변경함

# Related to
- #259 
