### PR TITLE
Hot Fix: 폴더 목록 불러오기 API의 공유 멤버에서 잘못된 ID 필드를 전달하고 있는 문제 해결

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/folder/presentation/dto/MyFoldersResponse.java
+++ b/src/main/java/com/flytrap/rssreader/api/folder/presentation/dto/MyFoldersResponse.java
@@ -64,7 +64,7 @@ public record MyFoldersResponse(
     ) {
         public static SharedMemberSummary from(SharedMember sharedMember) {
             return new SharedMemberSummary(
-                sharedMember.getId().value(),
+                sharedMember.getAccountId().value(),
                 sharedMember.getName(),
                 sharedMember.getProfileUrl()
             );


### PR DESCRIPTION
## 🔑 Key Changes
- 

## 👩‍💻 To Reviewers
- 공유 멤버 ID 에 AccountId가 들어가야 하는데 다른 ID가 들어가고 있었다. 테스트 할 때 SharedMember와 AccountId가 순서대로 생성되어서 에러가 안 난 것 같다...

## Related to
- #280 
