### PR TITLE
게시글 파싱 여러번 실패 시 게시글 수집을 차단하는 기능 추가

### DIFF
--- a/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/domain/PostIdGenerator.java
@@ -14,15 +14,21 @@ import org.springframework.stereotype.Component;
 public class PostIdGenerator {
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-    private static final String hashAlgorithm = "SHA-1";
+    private static final String HASH_ALGORITHM = "SHA-1";
+    private static final MessageDigest MESSAGE_DIGEST;
 
-    public static PostId generateString(Instant pubDate, String guid)
-        throws NoSuchAlgorithmException
-    {
+    static {
+        try {
+            MESSAGE_DIGEST = MessageDigest.getInstance(HASH_ALGORITHM);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static PostId generate(Instant pubDate, String guid) {
         ZonedDateTime zonedDateTime = pubDate.atZone(ZoneOffset.UTC);
 
-        MessageDigest messageDigest = MessageDigest.getInstance(hashAlgorithm);
-        byte[] digest = messageDigest.digest(guid.getBytes(StandardCharsets.UTF_8));
+        byte[] digest = MESSAGE_DIGEST.digest(guid.getBytes(StandardCharsets.UTF_8));
         String hashValue = DatatypeConverter.printHexBinary(digest).toLowerCase();
 
         return new PostId(zonedDateTime.format(formatter) + "-" + hashValue);

--- a/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
+++ b/src/main/java/com/flytrap/rssreader/api/post/infrastructure/system/PostCollectSystem.java
@@ -16,7 +16,6 @@ import com.flytrap.rssreader.api.subscribe.infrastructure.repository.RssSourceJp
 import com.flytrap.rssreader.global.event.GlobalEventPublisher;
 import com.flytrap.rssreader.global.utill.SimpleConcurrentPriorityQueue;
 import com.flytrap.rssreader.global.utill.SimplePriorityQueue;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -43,6 +42,10 @@ public class PostCollectSystem {
     private final GlobalEventPublisher globalEventPublisher;
     private final PostCollectionThreadPoolExecutor postCollectionThreadPoolExecutor;
 
+    public void enqueueHighPrioritySubscription(RssSourceEntity rssSourceEntity) {
+        collectionQueue.add(rssSourceEntity, CollectPriority.HIGH);
+    }
+
     public void loadAndEnqueueRssResources(int selectBatchSize) {
         var pageable = PageRequest.of(
             0, selectBatchSize,
@@ -65,23 +68,13 @@ public class PostCollectSystem {
 
             RssSourceEntity rssSource = collectionQueue.poll();
 
-            CompletableFuture<CollectionResult> future = postCollectionThreadPoolExecutor.supplyAsync(
-                () -> postParser.parseRssDocuments(rssSource.getUrl())
-                    .map(rssPostsData -> {
-                        int upsertCount = postMyBatisRepository.bulkUpsert(
-                            generateCollectedPostsForUpsert(rssPostsData, rssSource));
-
-                        rssSource.updateTitle(rssPostsData.rssSourceTitle());
-                        rssSource.updateLastCollectedAt(start);
-                        rssSourceRepository.save(rssSource);
-
-                        if (upsertCount >= 0) {
-                            return new CollectionResult(1, upsertCount, 0, 0);
-                        } else {
-                            return new CollectionResult(1, 0, 0, upsertCount * -1);
-                        }
-                    })
-                    .orElse(new CollectionResult(0, 0, 1, 0)));
+            CompletableFuture<CollectionResult> future = postCollectionThreadPoolExecutor
+                .supplyAsync(() -> {
+                        Optional<RssPostsData> rssPostsData = postParser
+                            .parseRssDocuments(rssSource.getUrl());
+                        return saveParsedPosts(rssPostsData, rssSource, start);
+                    }
+                );
 
             futures.add(future);
         }
@@ -89,14 +82,77 @@ public class PostCollectSystem {
         summarizeAndSaveCollectionResults(start, futures);
     }
 
-    public void enqueueHighPrioritySubscription(RssSourceEntity rssSourceEntity) {
-        collectionQueue.add(rssSourceEntity, CollectPriority.HIGH);
+    /**
+     * 파싱된 RSS 데이터를 DB에 반영한다
+     *
+     * @param rssPostsData 파싱된 RSS 데이터
+     * @param rssSource    파싱에 사용된 원본 RSS 문서 Entity
+     * @param start        파싱 시작 시간
+     * @return 파싱 및 저장 결과에 대한 통계 정보
+     */
+    private CollectionResult saveParsedPosts(
+        Optional<RssPostsData> rssPostsData, RssSourceEntity rssSource, Instant start
+    ) {
+        return rssPostsData
+            .map(data -> {
+                int upsertCount = postMyBatisRepository.bulkUpsert(
+                    generatePostEntitiesForUpsert(data, rssSource));
+
+                rssSource.updateTitle(data.rssSourceTitle());
+                rssSource.updateLastCollectedAt(start);
+                rssSourceRepository.save(rssSource);
+
+                if (upsertCount >= 0) {
+                    return new CollectionResult(1, upsertCount, 0, 0);
+                } else {
+                    return new CollectionResult(1, 0, 0, upsertCount * -1);
+                }
+            })
+            .orElse(new CollectionResult(0, 0, 1, 0));
+    }
+
+    /**
+     * 파싱한 게시글 리스트 데이터를 PostEntity 리스트로 변환해서 반환한다
+     *
+     * @param postData    파싱한 게시글 리스트 데이터
+     * @param rssResource 게시글을 파싱했던 RssResource Entity
+     * @return 파싱한 게시글 리스트 데이터에서 변환된 PostEntity 리스트
+     */
+    private List<PostEntity> generatePostEntitiesForUpsert(RssPostsData postData,
+        RssSourceEntity rssResource) {
+
+        Optional<PostEntity> latestPost = postRepository
+            .findFirstByRssSourceIdOrderByPubDateDesc(rssResource.getId());
+        Instant standardPubDate = latestPost.isPresent() // 신규 게시글을 분류하기 위한 기준으로 사용됨
+            ? latestPost.get().getPubDate()
+            : Instant.now();
+
+        List<PostEntity> collectedPosts = new ArrayList<>();
+        List<PostEntity> newPosts = new ArrayList<>();
+
+        for (RssPostsData.RssItemData itemData : postData.itemData()) {
+            PostId postId = PostIdGenerator.generate(itemData.pubDate(), itemData.guid());
+            PostEntity post = PostEntity.create(postId, itemData, rssResource.getId());
+
+            if (standardPubDate.compareTo(post.getPubDate()) < 0) {
+                // standardPubDate가 post.getPubDate()보다 이른 시간일 경우 해당 post는 신규 게시글로 취급한다
+                // 신규 게시글을 따로 분류하는 이유는 신규 게시글 알림을 보내기 위해서
+                newPosts.add(post);
+            }
+            collectedPosts.add(post);
+        }
+
+        if (!newPosts.isEmpty()) {
+            globalEventPublisher.publish(new NewPostAlertEvent(rssResource, newPosts));
+        }
+
+        return collectedPosts;
     }
 
     /**
      * 멀티 스레드로 동시 작업한 게시글 수집 결과를 집계하여 DB에 저장한다.
      *
-     * @param start 게시글 수집 시작 시간
+     * @param start   게시글 수집 시작 시간
      * @param futures 게시글 수집 작업의 CompletableFuture 목록
      */
     private void summarizeAndSaveCollectionResults(
@@ -130,41 +186,6 @@ public class PostCollectSystem {
                         .build()
                 );
             }).join();
-    }
-
-    private List<PostEntity> generateCollectedPostsForUpsert(RssPostsData postData,
-        RssSourceEntity rssResource) {
-
-        Optional<PostEntity> latestPost = postRepository
-            .findFirstByRssSourceIdOrderByPubDateDesc(rssResource.getId());
-        Instant standardPubDate = latestPost.isPresent()
-            ? latestPost.get().getPubDate()
-            : Instant.now();
-
-        List<PostEntity> collectedPosts = new ArrayList<>();
-        List<PostEntity> newPosts = new ArrayList<>();
-
-        for (RssPostsData.RssItemData itemData : postData.itemData()) {
-            PostId postId = null;
-            try {
-                postId = PostIdGenerator.generateString(itemData.pubDate(), itemData.guid());
-            } catch (NoSuchAlgorithmException e) {
-                return collectedPosts;
-            }
-            PostEntity post = PostEntity.create(postId, itemData, rssResource.getId());
-
-            if (standardPubDate.compareTo(post.getPubDate()) < 0) {
-                // standardPubDate가 post.getPubDate()보다 이른 시간일 경우 해당 post는 신규 게시글로 취급한다
-                newPosts.add(post);
-            }
-            collectedPosts.add(post);
-        }
-
-        if (!newPosts.isEmpty()) {
-            globalEventPublisher.publish(new NewPostAlertEvent(rssResource, newPosts));
-        }
-
-        return collectedPosts;
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RestrictionPolicy.java
+++ b/src/main/java/com/flytrap/rssreader/api/subscribe/domain/RestrictionPolicy.java
@@ -1,0 +1,31 @@
+package com.flytrap.rssreader.api.subscribe.domain;
+
+import java.time.Instant;
+import java.time.Period;
+import java.util.function.Predicate;
+
+public enum RestrictionPolicy {
+    NO_RESTRICTION_LEVEL(Period.ofDays(0), failCount -> failCount < 3),
+    FIRST_RESTRICTION_LEVEL(Period.ofDays(1), failCount -> failCount == 3),
+    SECOND_RESTRICTION_LEVEL(Period.ofDays(3), failCount -> failCount == 4),
+    THIRD_RESTRICTION_LEVEL(Period.ofDays(7), failCount -> failCount == 5),
+    FOURTH_RESTRICTION_LEVEL(Period.ofDays(30), failCount -> failCount >= 6 && failCount < 10),
+    MAXIMUM_RESTRICTION_LEVEL(Period.ofDays(300 * 365), failCount -> failCount >= 10);
+
+    private final Period restrictionPeriod;
+    private final Predicate<Integer> condition;
+
+    RestrictionPolicy(Period restrictionPeriod, Predicate<Integer> condition) {
+        this.restrictionPeriod = restrictionPeriod;
+        this.condition = condition;
+    }
+
+    public static Instant calculateRestrictionDate(int failCount, Instant referenceData) {
+        for (RestrictionPolicy policy : RestrictionPolicy.values()) {
+            if (policy.condition.test(failCount)) {
+                return referenceData.plus(policy.restrictionPeriod);
+            }
+        }
+        return referenceData;
+    }
+}

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -16,7 +16,9 @@ CREATE TABLE IF NOT EXISTS `rss_source`
     `title`             varchar(2500),
     `url`               varchar(2500) NOT NULL,
     `platform`          varchar(25),
-    `last_collected_at` datetime(6)
+    `last_collected_at` datetime(6),
+    `fail_count`        datetime(6),
+    `restriction_until` datetime(6)
 );
 
 CREATE TABLE IF NOT EXISTS `post`


### PR DESCRIPTION
#  🔑 Key Changes
- 게시글 파싱 여러번 실패 시 게시글 수집을 차단하는 기능 추가

# 👩‍💻 To Reviewers
## 문제
- RSS 문서의 링크가 잘못되었거나 포맷이 깨진 경우가 있다. 이러한 잘못된 RSS 문서는 파싱 도중 에러가 발생하여 게시글 수집 여부가 마크되지 않는다. 수집 여부가 마크되지 않은 게시글은 다음 수집 사이클에 다시 처리해야 할 작업으로 등록되므로, 게시글 수집 작업이 지연되는 문제가 발생한다.

## 해결 방법
- Circuit Breaker 패턴을 차용하여 해결
  - 시스템이 정상 작동할 때는 작업을 처리
  - 시스템이 비정상일 때는 작업을 차단
  - 차단된 시스템은 일정 간격으로 작업을 재시도 하여 시스템이 정상 작동 할 경우 차단 해제

### 차단 정책
- RSS 문서 파싱 실패시 실패 횟수를 저장한다
- 실패 횟수에 따라 차단 기한을 설정하여 해당 기간동안은 문서를 파싱하지 않는다

|실패 횟수|차단 기한|
|---|---|
|3|하루|
|4|3일|
|5|7일|
|6~9|30일|
|10|무기한 차단|

## 기타
### RssSource Entity에 필드 추가
- failCount: 게시글 수집 작업 실패 횟수
- restrictionUntil: 차단 기한

## Related to
- #284 
